### PR TITLE
Add bond analysis and persistent annotations

### DIFF
--- a/bondorder.f90
+++ b/bondorder.f90
@@ -342,6 +342,176 @@ end if
 end subroutine
 
 
+!!------ Return Mayer bond-order data for one atom pair without interactive output
+subroutine calc_bond_pair_mayer(iatm,jatm,bndord,bndorda,bndordb,gwbo,ierror)
+use defvar
+use util
+implicit none
+integer,intent(in) :: iatm,jatm
+integer,intent(out) :: ierror
+integer :: ibas,jbas
+real*8,intent(out) :: bndord,bndorda,bndordb,gwbo
+real*8,allocatable :: PSmat(:,:),PSmata(:,:),PSmatb(:,:)
+
+bndord=0D0
+bndorda=0D0
+bndordb=0D0
+gwbo=0D0
+ierror=0
+if (iatm<1.or.iatm>ncenter.or.jatm<1.or.jatm>ncenter.or.iatm==jatm) then
+    ierror=1
+    return
+end if
+if (.not.allocated(Ptot).or..not.allocated(Sbas).or..not.allocated(basstart).or..not.allocated(basend)) then
+    ierror=2
+    return
+end if
+if (basstart(iatm)==0.or.basstart(jatm)==0) then
+    ierror=3
+    return
+end if
+
+allocate(PSmat(nbasis,nbasis))
+PSmat=matmul_blas(Ptot,Sbas,nbasis,nbasis)
+do ibas=basstart(iatm),basend(iatm)
+    do jbas=basstart(jatm),basend(jatm)
+        gwbo=gwbo+PSmat(ibas,jbas)*PSmat(jbas,ibas)
+    end do
+end do
+
+if (wfntype==1.or.wfntype==2.or.wfntype==4) then
+    if (.not.allocated(Palpha).or..not.allocated(Pbeta)) then
+        ierror=2
+        deallocate(PSmat)
+        return
+    end if
+    allocate(PSmata(nbasis,nbasis),PSmatb(nbasis,nbasis))
+    PSmata=matmul_blas(Palpha,Sbas,nbasis,nbasis)
+    PSmatb=matmul_blas(Pbeta,Sbas,nbasis,nbasis)
+    do ibas=basstart(iatm),basend(iatm)
+        do jbas=basstart(jatm),basend(jatm)
+            bndorda=bndorda+PSmata(ibas,jbas)*PSmata(jbas,ibas)
+            bndordb=bndordb+PSmatb(ibas,jbas)*PSmatb(jbas,ibas)
+        end do
+    end do
+    bndorda=2D0*bndorda
+    bndordb=2D0*bndordb
+    bndord=bndorda+bndordb
+    deallocate(PSmata,PSmatb)
+else
+    bndord=gwbo
+end if
+deallocate(PSmat)
+end subroutine
+
+
+!!------ Return Mulliken bond-order data for one atom pair without interactive output
+subroutine calc_bond_pair_mulliken(iatm,jatm,bndord,bndorda,bndordb,ierror)
+use defvar
+implicit none
+integer,intent(in) :: iatm,jatm
+integer,intent(out) :: ierror
+real*8,intent(out) :: bndord,bndorda,bndordb
+
+bndord=0D0
+bndorda=0D0
+bndordb=0D0
+ierror=0
+if (iatm<1.or.iatm>ncenter.or.jatm<1.or.jatm>ncenter.or.iatm==jatm) then
+    ierror=1
+    return
+end if
+if (.not.allocated(Ptot).or..not.allocated(Sbas).or..not.allocated(basstart).or..not.allocated(basend)) then
+    ierror=2
+    return
+end if
+if (basstart(iatm)==0.or.basstart(jatm)==0) then
+    ierror=3
+    return
+end if
+
+if (wfntype==1.or.wfntype==2.or.wfntype==4) then
+    if (.not.allocated(Palpha).or..not.allocated(Pbeta)) then
+        ierror=2
+        return
+    end if
+    bndorda=2D0*sum(Palpha(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm))* &
+        Sbas(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm)))
+    bndordb=2D0*sum(Pbeta(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm))* &
+        Sbas(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm)))
+    bndord=bndorda+bndordb
+else
+    bndord=2D0*sum(Ptot(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm))* &
+        Sbas(basstart(iatm):basend(iatm),basstart(jatm):basend(jatm)))
+end if
+end subroutine
+
+
+!!------ Return Lowdin-orthogonalized Wiberg data for one atom pair without changing global matrices
+subroutine calc_bond_pair_lowdin(iatm,jatm,bndord,bndorda,bndordb,mixedord,ierror)
+use defvar
+use util
+implicit none
+integer,intent(in) :: iatm,jatm
+integer,intent(out) :: ierror
+integer :: ibas,jbas
+real*8,intent(out) :: bndord,bndorda,bndordb,mixedord
+real*8,allocatable :: Xmat(:,:),Xmatinv(:,:),tmpmat(:,:),Porth(:,:),Portha(:,:),Porthb(:,:)
+
+bndord=0D0
+bndorda=0D0
+bndordb=0D0
+mixedord=0D0
+ierror=0
+if (iatm<1.or.iatm>ncenter.or.jatm<1.or.jatm>ncenter.or.iatm==jatm) then
+    ierror=1
+    return
+end if
+if (.not.allocated(Ptot).or..not.allocated(Sbas).or..not.allocated(basstart).or..not.allocated(basend)) then
+    ierror=2
+    return
+end if
+if (basstart(iatm)==0.or.basstart(jatm)==0) then
+    ierror=3
+    return
+end if
+
+allocate(Xmat(nbasis,nbasis),Xmatinv(nbasis,nbasis),tmpmat(nbasis,nbasis),Porth(nbasis,nbasis))
+call symmorthomat(Sbas,Xmat,Xmatinv)
+tmpmat=matmul_blas(Xmat,Ptot,nbasis,nbasis)
+Porth=matmul_blas(tmpmat,Xmat,nbasis,nbasis)
+do ibas=basstart(iatm),basend(iatm)
+    do jbas=basstart(jatm),basend(jatm)
+        mixedord=mixedord+Porth(ibas,jbas)*Porth(jbas,ibas)
+    end do
+end do
+
+if (wfntype==1.or.wfntype==2.or.wfntype==4) then
+    if (.not.allocated(Palpha).or..not.allocated(Pbeta)) then
+        ierror=2
+        deallocate(Xmat,Xmatinv,tmpmat,Porth)
+        return
+    end if
+    allocate(Portha(nbasis,nbasis),Porthb(nbasis,nbasis))
+    tmpmat=matmul_blas(Xmat,Palpha,nbasis,nbasis)
+    Portha=matmul_blas(tmpmat,Xmat,nbasis,nbasis)
+    tmpmat=matmul_blas(Xmat,Pbeta,nbasis,nbasis)
+    Porthb=matmul_blas(tmpmat,Xmat,nbasis,nbasis)
+    do ibas=basstart(iatm),basend(iatm)
+        do jbas=basstart(jatm),basend(jatm)
+            bndorda=bndorda+Portha(ibas,jbas)*Portha(jbas,ibas)
+            bndordb=bndordb+Porthb(ibas,jbas)*Porthb(jbas,ibas)
+        end do
+    end do
+    bndorda=2D0*bndorda
+    bndordb=2D0*bndordb
+    bndord=bndorda+bndordb
+    deallocate(Portha,Porthb)
+else
+    bndord=mixedord
+end if
+deallocate(Xmat,Xmatinv,tmpmat,Porth)
+end subroutine
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/frontend/3dmol-viewer/README.md
+++ b/frontend/3dmol-viewer/README.md
@@ -29,6 +29,8 @@ Implemented:
 - Draw cube slices as 2D heatmaps.
 - Load simple 2D curve and filled-map data from CSV or JSON.
 - Extract atom positions from a cube file when no separate structure is loaded.
+- Select atoms with the right mouse button, identify bonds from 3Dmol's bond
+  topology, and annotate bond lengths and supported Multiwfn bond orders.
 - Load a JSON manifest produced by an external wrapper.
 - Export a PNG snapshot and a lightweight scene manifest.
 
@@ -58,6 +60,17 @@ Example manifest:
 ```json
 {
   "structure": { "path": "water.xyz", "format": "xyz" },
+  "bondAnalysis": {
+    "periodicSupported": false,
+    "openShell": false,
+    "methods": {
+      "mayer": { "available": true },
+      "gwbo": { "available": false, "reason": "GWBO is only distinct for open-shell wavefunctions" },
+      "wiberg_lowdin": { "available": true },
+      "mulliken": { "available": true },
+      "fbo": { "available": true }
+    }
+  },
   "cubes": [
     {
       "path": "homo.cube",
@@ -97,6 +110,11 @@ Example manifest:
 Relative manifest paths work when the directory is served over HTTP. Browsers
 cannot fetch arbitrary neighboring files from a locally opened `file://` page,
 so use a static server for manifest-based workflows.
+
+The generated GUI service exposes bond orders through
+`GET /api/bond?atom1=1&atom2=2&method=mayer`. Atom indices are one-based and
+the response contains `value` plus spin components when applicable. Bond
+length is calculated locally and does not call this endpoint.
 
 3Dmol.js references used while implementing this prototype:
 

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -190,6 +190,30 @@ const orbitalPhaseColors = {
   negative: '#5bcefa'
 };
 
+const atomSelectionColor = '#ffd400';
+const atomClickSphereRadius = 0.45;
+const bondPropertyDefinitions = [
+  { id: 'length', label: 'Bond length', backend: false },
+  { id: 'mayer', label: 'Mayer', backend: true },
+  { id: 'gwbo', label: 'GWBO', backend: true, openShellOnly: true },
+  { id: 'wiberg_lowdin', label: 'Wiberg (Lowdin)', backend: true },
+  { id: 'mulliken', label: 'Mulliken', backend: true },
+  { id: 'fbo', label: 'FBO', backend: true }
+];
+
+function defaultBondAnalysisCapabilities() {
+  const reason = 'Multiwfn bond-order backend is unavailable for this session';
+  return {
+    periodicSupported: false,
+    openShell: false,
+    methods: Object.fromEntries(
+      bondPropertyDefinitions
+        .filter((property) => property.backend)
+        .map((property) => [property.id, { available: false, reason }])
+    )
+  };
+}
+
 const roleDefaults = {
   homo: { label: 'HOMO', ...orbitalPhaseColors, isovalue: 0.015 },
   lumo: { label: 'LUMO', ...orbitalPhaseColors, isovalue: 0.015 },
@@ -262,6 +286,24 @@ const state = {
     manifestOrbitalLoads: new Map()
   },
   orbitalShapes: new Map(),
+  atomSelection: {
+    indices: new Set(),
+    model: null,
+    labels: []
+  },
+  bondAnalysis: {
+    capabilities: defaultBondAnalysisCapabilities(),
+    baseCapabilities: defaultBondAnalysisCapabilities(),
+    resultCache: new Map(),
+    annotations: new Map(),
+    requestBusy: false,
+    generation: 0,
+    context: {
+      clickedAtomIndex: null,
+      bonds: [],
+      activeBondKey: ''
+    }
+  },
   activePlot: null,
   selectedCubeFile: null,
   selectedPlotFile: null,
@@ -380,6 +422,12 @@ function getCellVectors() {
 }
 
 function syncPeriodicFromControls() {
+  const previousStructureKey = JSON.stringify({
+    enabled: state.periodic.enabled,
+    cell: state.periodic.cell,
+    ranges: state.periodic.ranges,
+    repeatMode: state.periodic.repeatMode
+  });
   state.periodic.enabled = els.periodicEnabled.checked;
   state.periodic.showUnitCell = els.showUnitCell.checked;
   state.periodic.tileCubes = els.tileCubes.checked;
@@ -395,6 +443,17 @@ function syncPeriodicFromControls() {
   };
   state.periodic.repeatMode = els.structureRepeatMode.value;
   state.periodic.cubeRepeatCap = clamp(parseInt(els.cubeRepeatCap.value, 10) || 8, 1, 27);
+  const nextStructureKey = JSON.stringify({
+    enabled: state.periodic.enabled,
+    cell: state.periodic.cell,
+    ranges: state.periodic.ranges,
+    repeatMode: state.periodic.repeatMode
+  });
+  if (previousStructureKey !== nextStructureKey) {
+    clearAtomSelectionState();
+    clearBondAnalysisState();
+    refreshBondAnalysisCapabilities();
+  }
 }
 
 function parseStructureAtomCount(data, format) {
@@ -637,6 +696,776 @@ function applySceneStyle() {
   state.viewer.spin(els.spin.checked);
 }
 
+function clearAtomSelectionState() {
+  state.atomSelection.indices.clear();
+  state.atomSelection.model = null;
+  state.atomSelection.labels = [];
+}
+
+function resetAtomDecorationReferences() {
+  state.atomSelection.model = null;
+  state.atomSelection.labels = [];
+}
+
+function removeTrackedAtomLabels() {
+  if (!state.viewer) return;
+  state.atomSelection.labels.forEach((label) => {
+    if (label && typeof state.viewer.removeLabel === 'function') state.viewer.removeLabel(label);
+  });
+  state.atomSelection.labels = [];
+}
+
+function atomDisplayIndex(atom, fallback = 0) {
+  const index = Number(atom?.index);
+  return Number.isFinite(index) && index >= 0 ? index : fallback;
+}
+
+function atomDisplayName(atom, fallback = 0) {
+  const element = String(atom?.elem || atom?.atom || 'X');
+  return `${element}${atomDisplayIndex(atom, fallback) + 1}`;
+}
+
+function atomMapForModel(model = state.atomSelection.model) {
+  if (!model || typeof model.selectedAtoms !== 'function') return new Map();
+  return new Map(model.selectedAtoms({}).map((atom, fallback) => [atomDisplayIndex(atom, fallback), atom]));
+}
+
+function bondPairKey(atom1Index, atom2Index) {
+  const low = Math.min(Number(atom1Index), Number(atom2Index));
+  const high = Math.max(Number(atom1Index), Number(atom2Index));
+  return `${low}:${high}`;
+}
+
+function makeSelectedBond(atom1, atom2) {
+  const atom1Index = atomDisplayIndex(atom1);
+  const atom2Index = atomDisplayIndex(atom2);
+  const first = atom1Index <= atom2Index ? atom1 : atom2;
+  const second = atom1Index <= atom2Index ? atom2 : atom1;
+  const firstIndex = atomDisplayIndex(first);
+  const secondIndex = atomDisplayIndex(second);
+  const dx = Number(second.x) - Number(first.x);
+  const dy = Number(second.y) - Number(first.y);
+  const dz = Number(second.z) - Number(first.z);
+  return {
+    key: bondPairKey(firstIndex, secondIndex),
+    atom1Index: firstIndex,
+    atom2Index: secondIndex,
+    atom1Name: atomDisplayName(first, firstIndex),
+    atom2Name: atomDisplayName(second, secondIndex),
+    label: `${atomDisplayName(first, firstIndex)}-${atomDisplayName(second, secondIndex)}`,
+    length: Math.sqrt(dx * dx + dy * dy + dz * dz),
+    atom1Position: { x: Number(first.x), y: Number(first.y), z: Number(first.z) },
+    atom2Position: { x: Number(second.x), y: Number(second.y), z: Number(second.z) },
+    midpoint: {
+      x: (Number(first.x) + Number(second.x)) / 2,
+      y: (Number(first.y) + Number(second.y)) / 2,
+      z: (Number(first.z) + Number(second.z)) / 2
+    }
+  };
+}
+
+function selectedAdjacentBonds(model = state.atomSelection.model) {
+  const atoms = atomMapForModel(model);
+  const selected = state.atomSelection.indices;
+  const bonds = new Map();
+  selected.forEach((atomIndex) => {
+    const atom = atoms.get(atomIndex);
+    if (!atom || !Array.isArray(atom.bonds)) return;
+    atom.bonds.forEach((neighborValue) => {
+      const neighborIndex = Number(neighborValue);
+      if (!selected.has(neighborIndex) || neighborIndex === atomIndex) return;
+      const neighbor = atoms.get(neighborIndex);
+      if (!neighbor) return;
+      const bond = makeSelectedBond(atom, neighbor);
+      bonds.set(bond.key, bond);
+    });
+  });
+  return [...bonds.values()].sort((left, right) => (
+    left.atom1Index - right.atom1Index || left.atom2Index - right.atom2Index
+  ));
+}
+
+function bondPropertyDefinition(method) {
+  return bondPropertyDefinitions.find((property) => property.id === method);
+}
+
+function formatBondValue(method, value) {
+  if (!Number.isFinite(Number(value))) return '';
+  if (method === 'length') return `${Number(value).toFixed(4)} \u00c5`;
+  return Number(value).toFixed(6).replace(/\.?0+$/, '');
+}
+
+function selectedAtomModelStyle() {
+  const style = modelStyle();
+  ['line', 'stick', 'sphere'].forEach((key) => {
+    if (!style[key]) return;
+    delete style[key].colorscheme;
+    style[key].color = atomSelectionColor;
+  });
+  return style;
+}
+
+function addTrackedAtomLabel(text, atom, selected = false) {
+  const label = state.viewer.addLabel(text, {
+    position: { x: atom.x, y: atom.y, z: atom.z },
+    fontSize: clamp(Math.round(state.gui.labelSize / 3), selected ? 10 : 8, 24),
+    fontColor: '#111820',
+    backgroundColor: selected ? '#fff3a3' : 'rgba(255,255,255,0.78)',
+    backgroundOpacity: selected ? 0.92 : 0.72,
+    borderThickness: selected ? 1 : 0.4,
+    borderColor: selected ? '#8a6500' : '#d8e0e6',
+    inFront: selected
+  }, undefined, true);
+  state.atomSelection.labels.push(label);
+}
+
+function atomSelectionSpec(indices) {
+  const values = Array.isArray(indices) ? indices : [indices];
+  return { index: values.length === 1 ? values[0] : values };
+}
+
+function enableAtomContextSelection(model, selection = {}) {
+  if (!model) return;
+  if (typeof model.setStyle === 'function') {
+    model.setStyle(selection, { clicksphere: { radius: atomClickSphereRadius } }, true);
+  }
+  if (typeof model.setClickable === 'function') model.setClickable(selection, true, () => {});
+  if (typeof model.enableContextMenu === 'function') model.enableContextMenu(selection, true);
+}
+
+function applyAtomSelectionStyle(model, indices, selected) {
+  const values = (Array.isArray(indices) ? indices : [indices])
+    .map(Number)
+    .filter((index) => Number.isFinite(index) && index >= 0);
+  if (!model || !values.length || typeof model.setStyle !== 'function') return;
+  const selection = atomSelectionSpec(values);
+  model.setStyle(selection, selected ? selectedAtomModelStyle() : modelStyle());
+  enableAtomContextSelection(model, selection);
+}
+
+function renderAtomSelectionDecorations(model = state.atomSelection.model, options = {}) {
+  removeTrackedAtomLabels();
+  state.atomSelection.model = model || null;
+  if (!model || typeof model.selectedAtoms !== 'function') return [];
+
+  const atoms = model.selectedAtoms({});
+  const validIndices = new Set(atoms.map((atom, index) => atomDisplayIndex(atom, index)));
+  [...state.atomSelection.indices].forEach((index) => {
+    if (!validIndices.has(index)) state.atomSelection.indices.delete(index);
+  });
+  const selectedIndices = [...state.atomSelection.indices];
+  if (options.applyStyles !== false && selectedIndices.length) {
+    applyAtomSelectionStyle(model, selectedIndices, true);
+  }
+
+  if (els.showLabels.checked) {
+    atoms.slice(0, 500).forEach((atom, index) => {
+      if (state.atomSelection.indices.has(atomDisplayIndex(atom, index))) return;
+      addTrackedAtomLabel(atomDisplayName(atom, index), atom);
+    });
+  }
+
+  atoms.forEach((atom, index) => {
+    const atomIndex = atomDisplayIndex(atom, index);
+    if (state.atomSelection.indices.has(atomIndex)) {
+      addTrackedAtomLabel(atomDisplayName(atom, index), atom, true);
+    }
+  });
+  return atoms;
+}
+
+function bondResultCacheKey(bond, method) {
+  return `${state.bondAnalysis.generation}:${bond.key}:${method}`;
+}
+
+function closeBondSubmenu(options = {}) {
+  const focusTarget = els.bondContextMenu?.querySelector('button[aria-expanded="true"]');
+  if (els.bondContextSubmenu) {
+    els.bondContextSubmenu.hidden = true;
+    els.bondContextSubmenu.replaceChildren();
+  }
+  els.bondContextMenu?.querySelectorAll('[aria-expanded="true"]').forEach((button) => {
+    button.setAttribute('aria-expanded', 'false');
+  });
+  state.bondAnalysis.context.activeBondKey = '';
+  if (options.focus && focusTarget) focusTarget.focus();
+}
+
+function closeBondContextMenu() {
+  closeBondSubmenu();
+  if (els.bondContextMenu) {
+    els.bondContextMenu.hidden = true;
+    els.bondContextMenu.replaceChildren();
+  }
+  state.bondAnalysis.context.clickedAtomIndex = null;
+  state.bondAnalysis.context.bonds = [];
+}
+
+function clearBondAnalysisState(options = {}) {
+  closeBondContextMenu();
+  state.bondAnalysis.annotations.forEach((annotation) => annotation.element?.remove());
+  state.bondAnalysis.annotations.clear();
+  state.bondAnalysis.resultCache.clear();
+  state.bondAnalysis.requestBusy = false;
+  state.bondAnalysis.generation += 1;
+  syncBackendRequestControls();
+  if (options.resetCapabilities) {
+    state.bondAnalysis.capabilities = defaultBondAnalysisCapabilities();
+    state.bondAnalysis.baseCapabilities = defaultBondAnalysisCapabilities();
+  }
+  if (els.bondAnnotationLayer) els.bondAnnotationLayer.replaceChildren();
+}
+
+function ensureBondAnnotation(bond, options = {}) {
+  let annotation = state.bondAnalysis.annotations.get(bond.key);
+  if (!annotation) {
+    annotation = {
+      bond: { ...bond, midpoint: { ...bond.midpoint } },
+      results: new Map(),
+      pending: new Set(),
+      visible: true,
+      closeVersion: 0,
+      element: null
+    };
+    state.bondAnalysis.annotations.set(bond.key, annotation);
+  } else {
+    annotation.bond = { ...bond, midpoint: { ...bond.midpoint } };
+  }
+  if (options.show !== false) annotation.visible = true;
+  return annotation;
+}
+
+function hideBondAnnotation(bondKey) {
+  const annotation = state.bondAnalysis.annotations.get(bondKey);
+  if (!annotation) return;
+  annotation.visible = false;
+  annotation.closeVersion += 1;
+  annotation.element?.remove();
+  annotation.element = null;
+  updateBondAnnotationPositions();
+}
+
+function bondPropertyDetail(payload) {
+  const components = payload?.components || {};
+  const parts = [];
+  if (Number.isFinite(Number(components.alpha))) parts.push(`alpha ${formatBondValue(payload.method, components.alpha)}`);
+  if (Number.isFinite(Number(components.beta))) parts.push(`beta ${formatBondValue(payload.method, components.beta)}`);
+  if (Number.isFinite(Number(components.gwbo))) parts.push(`GWBO ${formatBondValue('gwbo', components.gwbo)}`);
+  if (Number.isFinite(Number(components.mixed))) parts.push(`mixed ${formatBondValue(payload.method, components.mixed)}`);
+  return parts.join(', ');
+}
+
+function renderBondAnnotation(annotation) {
+  if (!els.bondAnnotationLayer) return;
+  if (!annotation.visible || (!annotation.results.size && !annotation.pending.size)) {
+    annotation.element?.remove();
+    annotation.element = null;
+    return;
+  }
+  if (!annotation.element) {
+    const element = document.createElement('div');
+    element.className = 'bond-annotation';
+    element.dataset.bondKey = annotation.bond.key;
+
+    const title = document.createElement('div');
+    title.className = 'bond-annotation-title';
+    element.append(title);
+
+    const values = document.createElement('div');
+    values.className = 'bond-annotation-values';
+    element.append(values);
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'bond-annotation-close';
+    closeButton.textContent = 'x';
+    closeButton.title = 'Close bond annotation';
+    closeButton.setAttribute('aria-label', `Close ${annotation.bond.label} annotation`);
+    closeButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      hideBondAnnotation(annotation.bond.key);
+    });
+    element.append(closeButton);
+    els.bondAnnotationLayer.append(element);
+    annotation.element = element;
+  }
+
+  annotation.element.querySelector('.bond-annotation-title').textContent = annotation.bond.label;
+  const values = annotation.element.querySelector('.bond-annotation-values');
+  values.replaceChildren();
+  bondPropertyDefinitions.forEach((property) => {
+    const payload = annotation.results.get(property.id);
+    if (!payload && !annotation.pending.has(property.id)) return;
+    const row = document.createElement('div');
+    row.className = 'bond-annotation-row';
+    if (annotation.pending.has(property.id) && !payload) {
+      row.classList.add('is-pending');
+      row.textContent = `${property.label}: Calculating...`;
+    } else {
+      row.textContent = `${property.label}: ${formatBondValue(property.id, payload.value)}`;
+      const detail = bondPropertyDetail(payload);
+      if (detail) row.title = detail;
+    }
+    values.append(row);
+  });
+}
+
+function rectangleOverlapArea(left, top, width, height, rect) {
+  const overlapWidth = Math.max(0, Math.min(left + width, rect.right) - Math.max(left, rect.left));
+  const overlapHeight = Math.max(0, Math.min(top + height, rect.bottom) - Math.max(top, rect.top));
+  return overlapWidth * overlapHeight;
+}
+
+function updateBondAnnotationPositions() {
+  if (!els.bondAnnotationLayer || !state.viewer) return;
+  const plotVisible = els.plotPanel && !els.plotPanel.classList.contains('is-hidden');
+  const hideLayer = plotVisible || !els.showStructure?.checked || !state.structure.data;
+  els.bondAnnotationLayer.hidden = Boolean(hideLayer);
+  if (hideLayer || typeof state.viewer.modelToScreen !== 'function') return;
+
+  const wrapRect = els.viewerWrap.getBoundingClientRect();
+  const margin = 8;
+  const reserved = [];
+  [els.orientationWidget, ...els.viewerWrap.querySelectorAll('.hud span')].forEach((element) => {
+    if (!element || element.hidden) return;
+    const rect = element.getBoundingClientRect();
+    reserved.push({
+      left: rect.left - wrapRect.left,
+      top: rect.top - wrapRect.top,
+      right: rect.right - wrapRect.left,
+      bottom: rect.bottom - wrapRect.top
+    });
+  });
+  const atoms = atomMapForModel();
+  const atomScreens = [];
+  atoms.forEach((atom) => {
+    const projected = state.viewer.modelToScreen({ x: atom.x, y: atom.y, z: atom.z });
+    if (!projected || !Number.isFinite(projected.x) || !Number.isFinite(projected.y)) return;
+    const x = projected.x - wrapRect.left;
+    const y = projected.y - wrapRect.top;
+    atomScreens.push({ x, y });
+    reserved.push({ left: x - 30, top: y - 30, right: x + 30, bottom: y + 30 });
+  });
+  const atomCenter = atomScreens.length
+    ? atomScreens.reduce((sum, point) => ({ x: sum.x + point.x, y: sum.y + point.y }), { x: 0, y: 0 })
+    : { x: wrapRect.width / 2, y: wrapRect.height / 2 };
+  if (atomScreens.length) {
+    atomCenter.x /= atomScreens.length;
+    atomCenter.y /= atomScreens.length;
+  }
+
+  state.bondAnalysis.annotations.forEach((annotation) => renderBondAnnotation(annotation));
+  state.bondAnalysis.annotations.forEach((annotation) => {
+    const element = annotation.element;
+    if (!element || !annotation.visible) return;
+    const projected = state.viewer.modelToScreen(annotation.bond.midpoint);
+    if (!projected || !Number.isFinite(projected.x) || !Number.isFinite(projected.y)) {
+      element.hidden = true;
+      return;
+    }
+    element.hidden = false;
+    const anchorX = projected.x - wrapRect.left;
+    const anchorY = projected.y - wrapRect.top;
+    const width = element.offsetWidth;
+    const height = element.offsetHeight;
+    const atom1Screen = state.viewer.modelToScreen(annotation.bond.atom1Position);
+    const atom2Screen = state.viewer.modelToScreen(annotation.bond.atom2Position);
+    const bondDx = Number(atom2Screen?.x) - Number(atom1Screen?.x);
+    const bondDy = Number(atom2Screen?.y) - Number(atom1Screen?.y);
+    const bondScreenLength = Math.hypot(bondDx, bondDy) || 1;
+    const normalX = -bondDy / bondScreenLength;
+    const normalY = bondDx / bondScreenLength;
+    const outwardDx = anchorX - atomCenter.x;
+    const outwardDy = anchorY - atomCenter.y;
+    const outwardLength = Math.hypot(outwardDx, outwardDy) || 1;
+    const outwardX = outwardDx / outwardLength;
+    const outwardY = outwardDy / outwardLength;
+    const candidates = [];
+    [100, 140, 180].forEach((offset) => {
+      candidates.push([
+        anchorX + outwardX * offset - width / 2,
+        anchorY + outwardY * offset - height / 2
+      ]);
+    });
+    [88, 120, 152, 184].forEach((offset) => {
+      candidates.push([
+        anchorX + normalX * offset - width / 2,
+        anchorY + normalY * offset - height / 2
+      ]);
+      candidates.push([
+        anchorX - normalX * offset - width / 2,
+        anchorY - normalY * offset - height / 2
+      ]);
+    });
+    candidates.push(
+      [anchorX + 14, anchorY - height / 2],
+      [anchorX - width - 14, anchorY - height / 2],
+      [anchorX - width / 2, anchorY - height - 14],
+      [anchorX - width / 2, anchorY + 14]
+    );
+    const constrainedCandidates = candidates.map(([left, top]) => [
+      clamp(left, margin, Math.max(margin, wrapRect.width - width - margin)),
+      clamp(top, margin, Math.max(margin, wrapRect.height - height - margin))
+    ]);
+    const scored = constrainedCandidates.map(([left, top], index) => ({
+      left,
+      top,
+      index,
+      score: reserved.reduce((sum, rect) => sum + rectangleOverlapArea(left, top, width, height, rect), 0)
+    })).sort((left, right) => left.score - right.score || left.index - right.index);
+    const position = scored[0];
+    element.style.left = `${Math.round(position.left)}px`;
+    element.style.top = `${Math.round(position.top)}px`;
+    reserved.push({
+      left: position.left,
+      top: position.top,
+      right: position.left + width,
+      bottom: position.top + height
+    });
+  });
+}
+
+function bondMenuButtons(menu) {
+  return [...menu.querySelectorAll('button:not(:disabled)')];
+}
+
+function focusBondMenuButton(menu, direction) {
+  const buttons = bondMenuButtons(menu);
+  if (!buttons.length) return;
+  const current = buttons.indexOf(document.activeElement);
+  const next = current < 0 ? 0 : (current + direction + buttons.length) % buttons.length;
+  buttons[next].focus();
+}
+
+function handleBondMenuKeydown(event) {
+  const menu = event.currentTarget;
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    focusBondMenuButton(menu, event.key === 'ArrowDown' ? 1 : -1);
+    event.preventDefault();
+    return;
+  }
+  if (event.key === 'ArrowRight' && menu === els.bondContextMenu) {
+    const trigger = document.activeElement?.matches?.('button[data-bond-key]') ? document.activeElement : null;
+    if (trigger) {
+      trigger.click();
+      event.preventDefault();
+    }
+    return;
+  }
+  if ((event.key === 'ArrowLeft' || event.key === 'Escape') && menu === els.bondContextSubmenu) {
+    closeBondSubmenu({ focus: true });
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+  if (event.key === 'Escape' && menu === els.bondContextMenu) {
+    closeBondContextMenu();
+    state.viewer?.getCanvas?.().focus?.();
+    event.preventDefault();
+    event.stopPropagation();
+  }
+}
+
+function appendBondMenuHeading(menu, text) {
+  const heading = document.createElement('div');
+  heading.className = 'bond-context-heading';
+  heading.textContent = text;
+  menu.append(heading);
+}
+
+function appendBondMenuSeparator(menu) {
+  const separator = document.createElement('div');
+  separator.className = 'bond-context-separator';
+  separator.setAttribute('role', 'separator');
+  menu.append(separator);
+}
+
+function createBondMenuButton(label, options = {}) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.setAttribute('role', options.role || 'menuitem');
+  button.disabled = Boolean(options.disabled);
+  if (options.title) button.title = options.title;
+  const text = document.createElement('span');
+  text.className = 'bond-context-label';
+  text.textContent = label;
+  if (options.reason) {
+    const reason = document.createElement('span');
+    reason.className = 'bond-context-reason';
+    reason.textContent = options.reason;
+    text.append(reason);
+  }
+  button.append(text);
+  if (options.value) {
+    const value = document.createElement('span');
+    value.className = 'bond-context-value';
+    value.textContent = options.value;
+    button.append(value);
+  }
+  if (options.onClick) button.addEventListener('click', options.onClick);
+  return button;
+}
+
+function positionBondMenu(menu, left, top) {
+  if (!menu || menu.hidden) return;
+  const margin = 8;
+  const maxLeft = Math.max(margin, els.viewerWrap.clientWidth - menu.offsetWidth - margin);
+  const maxTop = Math.max(margin, els.viewerWrap.clientHeight - menu.offsetHeight - margin);
+  menu.style.left = `${Math.round(clamp(left, margin, maxLeft))}px`;
+  menu.style.top = `${Math.round(clamp(top, margin, maxTop))}px`;
+}
+
+function positionBondSubmenu(trigger, menu) {
+  const wrapRect = els.viewerWrap.getBoundingClientRect();
+  const triggerRect = trigger.getBoundingClientRect();
+  const margin = 8;
+  const gap = 2;
+  const right = triggerRect.right - wrapRect.left + gap;
+  const left = triggerRect.left - wrapRect.left - menu.offsetWidth - gap;
+  const desiredLeft = right + menu.offsetWidth <= els.viewerWrap.clientWidth - margin ? right : left;
+  positionBondMenu(menu, desiredLeft, triggerRect.top - wrapRect.top);
+}
+
+function bondMethodCapability(method) {
+  return state.bondAnalysis.capabilities?.methods?.[method] || {
+    available: false,
+    reason: 'Multiwfn bond-order backend is unavailable for this session'
+  };
+}
+
+function renderBondPropertyMenu(menu, bond) {
+  menu.replaceChildren();
+  appendBondMenuHeading(menu, bond.label);
+  bondPropertyDefinitions.forEach((property) => {
+    if (property.openShellOnly && !state.bondAnalysis.capabilities.openShell) return;
+    const cached = state.bondAnalysis.resultCache.get(bondResultCacheKey(bond, property.id));
+    const capability = property.backend ? bondMethodCapability(property.id) : { available: true };
+    const value = property.id === 'length'
+      ? formatBondValue('length', bond.length)
+      : cached ? formatBondValue(property.id, cached.value) : '';
+    const detail = cached ? bondPropertyDetail(cached) : '';
+    const button = createBondMenuButton(property.label, {
+      value,
+      disabled: property.backend && (
+        !capability.available || state.bondAnalysis.requestBusy || state.gui.orbitalRequestBusy
+      ),
+      reason: property.backend && !capability.available ? capability.reason : '',
+      title: detail || capability.reason || '',
+      onClick: () => {
+        closeBondContextMenu();
+        selectBondProperty(bond, property.id);
+      }
+    });
+    button.dataset.bondMethod = property.id;
+    menu.append(button);
+  });
+}
+
+function openBondPropertySubmenu(trigger, bond) {
+  els.bondContextMenu.querySelectorAll('[aria-expanded="true"]').forEach((button) => {
+    button.setAttribute('aria-expanded', 'false');
+  });
+  trigger.setAttribute('aria-expanded', 'true');
+  state.bondAnalysis.context.activeBondKey = bond.key;
+  renderBondPropertyMenu(els.bondContextSubmenu, bond);
+  els.bondContextSubmenu.hidden = false;
+  positionBondSubmenu(trigger, els.bondContextSubmenu);
+  requestAnimationFrame(() => bondMenuButtons(els.bondContextSubmenu)[0]?.focus());
+}
+
+function deselectAtomIndex(atomIndex) {
+  if (!state.atomSelection.indices.has(atomIndex)) return;
+  const atomName = atomDisplayName(atomMapForModel().get(atomIndex), atomIndex);
+  state.atomSelection.indices.delete(atomIndex);
+  applyAtomSelectionStyle(state.atomSelection.model, atomIndex, false);
+  renderAtomSelectionDecorations(state.atomSelection.model, { applyStyles: false });
+  state.viewer.render();
+  updateBondAnnotationPositions();
+  setStatus(`Deselected atom ${atomName} (${state.atomSelection.indices.size} selected)`);
+}
+
+function clearSelectedAtoms() {
+  const selectedIndices = [...state.atomSelection.indices];
+  if (!selectedIndices.length) return;
+  applyAtomSelectionStyle(state.atomSelection.model, selectedIndices, false);
+  state.atomSelection.indices.clear();
+  renderAtomSelectionDecorations(state.atomSelection.model, { applyStyles: false });
+  state.viewer.render();
+  updateBondAnnotationPositions();
+  setStatus('Atom selection cleared');
+}
+
+function openBondContextMenu(selected, x, y, bonds) {
+  closeBondContextMenu();
+  state.bondAnalysis.context.clickedAtomIndex = Number(selected.index);
+  state.bondAnalysis.context.bonds = bonds;
+  els.bondContextMenu.hidden = false;
+
+  if (bonds.length === 1) {
+    renderBondPropertyMenu(els.bondContextMenu, bonds[0]);
+  } else {
+    appendBondMenuHeading(els.bondContextMenu, 'Selected bonds');
+    bonds.forEach((bond) => {
+      const trigger = createBondMenuButton(bond.label, {
+        value: '>',
+        onClick: () => openBondPropertySubmenu(trigger, bond)
+      });
+      trigger.setAttribute('aria-haspopup', 'menu');
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.dataset.bondKey = bond.key;
+      els.bondContextMenu.append(trigger);
+    });
+  }
+
+  appendBondMenuSeparator(els.bondContextMenu);
+  const clickedName = atomDisplayName(selected, Number(selected.index));
+  els.bondContextMenu.append(createBondMenuButton(`Deselect ${clickedName}`, {
+    onClick: () => {
+      closeBondContextMenu();
+      deselectAtomIndex(Number(selected.index));
+    }
+  }));
+  els.bondContextMenu.append(createBondMenuButton('Clear atom selection', {
+    onClick: () => {
+      closeBondContextMenu();
+      clearSelectedAtoms();
+    }
+  }));
+  positionBondMenu(els.bondContextMenu, x, y);
+  requestAnimationFrame(() => bondMenuButtons(els.bondContextMenu)[0]?.focus());
+}
+
+function cacheRelatedOpenShellResults(bond, payload) {
+  if (!payload?.components) return;
+  if (payload.method === 'mayer' && Number.isFinite(Number(payload.components.gwbo))) {
+    state.bondAnalysis.resultCache.set(bondResultCacheKey(bond, 'gwbo'), {
+      ...payload,
+      method: 'gwbo',
+      value: Number(payload.components.gwbo)
+    });
+  }
+  if (payload.method === 'gwbo' && Number.isFinite(Number(payload.components.total))) {
+    state.bondAnalysis.resultCache.set(bondResultCacheKey(bond, 'mayer'), {
+      ...payload,
+      method: 'mayer',
+      value: Number(payload.components.total)
+    });
+  }
+}
+
+function syncBackendRequestControls() {
+  const busy = Boolean(state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy);
+  [
+    els.guiOrbitalSelect,
+    els.guiOrbitalInput,
+    els.guiOrbitalIsovalue,
+    els.guiOrbitalIsovalueNumber,
+    els.guiOrbPrev,
+    els.guiOrbNext,
+    els.guiMenuQuality
+  ].forEach((control) => {
+    if (control) control.disabled = busy;
+  });
+}
+
+function setBondRequestBusy(busy) {
+  state.bondAnalysis.requestBusy = Boolean(busy);
+  syncBackendRequestControls();
+}
+
+async function selectBondProperty(bond, method) {
+  const annotation = ensureBondAnnotation(bond);
+  const cached = state.bondAnalysis.resultCache.get(bondResultCacheKey(bond, method));
+  if (method === 'length') {
+    const payload = { ok: true, method, value: bond.length, components: { total: bond.length } };
+    state.bondAnalysis.resultCache.set(bondResultCacheKey(bond, method), payload);
+    annotation.results.set(method, payload);
+    renderBondAnnotation(annotation);
+    updateBondAnnotationPositions();
+    setStatus(`${bond.label} length: ${formatBondValue(method, bond.length)}`);
+    return;
+  }
+  if (cached) {
+    annotation.results.set(method, cached);
+    renderBondAnnotation(annotation);
+    updateBondAnnotationPositions();
+    setStatus(`${bondPropertyDefinition(method).label} loaded from cache`);
+    return;
+  }
+  if (state.bondAnalysis.requestBusy || state.gui.orbitalRequestBusy) {
+    setStatus('Multiwfn backend is busy', false);
+    return;
+  }
+
+  const generation = state.bondAnalysis.generation;
+  const closeVersion = annotation.closeVersion;
+  annotation.pending.add(method);
+  renderBondAnnotation(annotation);
+  updateBondAnnotationPositions();
+  setBondRequestBusy(true);
+  const property = bondPropertyDefinition(method);
+  setStatus(`Calculating ${property.label} for ${bond.label}...`);
+  const params = new URLSearchParams({
+    atom1: String(bond.atom1Index + 1),
+    atom2: String(bond.atom2Index + 1),
+    method
+  });
+  try {
+    const response = await fetch(`/api/bond?${params.toString()}`, { cache: 'no-store' });
+    const payload = await response.json();
+    if (!payload.ok) throw new Error(payload.message || `${property.label} calculation failed`);
+    if (!Number.isFinite(Number(payload.value))) throw new Error(`${property.label} returned an invalid value`);
+    payload.value = Number(payload.value);
+    if (generation !== state.bondAnalysis.generation) return;
+    state.bondAnalysis.resultCache.set(bondResultCacheKey(bond, method), payload);
+    cacheRelatedOpenShellResults(bond, payload);
+    annotation.pending.delete(method);
+    annotation.results.set(method, payload);
+    if (annotation.closeVersion === closeVersion) annotation.visible = true;
+    renderBondAnnotation(annotation);
+    updateBondAnnotationPositions();
+    setStatus(`${property.label} for ${bond.label}: ${formatBondValue(method, payload.value)}`);
+  } catch (error) {
+    console.error(error);
+    if (generation === state.bondAnalysis.generation) {
+      annotation.pending.delete(method);
+      renderBondAnnotation(annotation);
+      updateBondAnnotationPositions();
+    }
+    setStatus(error.message || `${property.label} calculation failed`, false);
+  } finally {
+    if (generation === state.bondAnalysis.generation) setBondRequestBusy(false);
+  }
+}
+
+function handleAtomContextMenu(selected, x = 0, y = 0) {
+  if (!selected || !Number.isFinite(Number(selected.index))) {
+    closeBondContextMenu();
+    clearSelectedAtoms();
+    return;
+  }
+
+  const atomIndex = Number(selected.index);
+  const wasSelected = state.atomSelection.indices.has(atomIndex);
+  if (wasSelected) {
+    const bonds = selectedAdjacentBonds();
+    if (bonds.length) {
+      openBondContextMenu(selected, x, y, bonds);
+      return;
+    }
+    state.atomSelection.indices.delete(atomIndex);
+  } else {
+    closeBondContextMenu();
+    state.atomSelection.indices.add(atomIndex);
+  }
+  applyAtomSelectionStyle(state.atomSelection.model, atomIndex, !wasSelected);
+  renderAtomSelectionDecorations(state.atomSelection.model, { applyStyles: false });
+  state.viewer.render();
+  updateBondAnnotationPositions();
+  const action = wasSelected ? 'Deselected' : 'Selected';
+  setStatus(`${action} atom ${atomDisplayName(selected, atomIndex)} (${state.atomSelection.indices.size} selected)`);
+}
+
 function addStructureToViewer() {
   let data = state.structure.data;
   let format = state.structure.format;
@@ -649,32 +1478,13 @@ function addStructureToViewer() {
   try {
     const display = getDisplayStructureData(data, format);
     const model = state.viewer.addModel(display.data, display.format);
-    state.viewer.setStyle({}, modelStyle());
-    if (els.showLabels.checked) addAtomLabels(model);
+    model.setStyle({}, modelStyle());
+    enableAtomContextSelection(model);
+    state.atomSelection.model = model;
     return model;
   } catch (error) {
     setStatus('Structure error', false);
     return null;
-  }
-}
-
-function addAtomLabels(model) {
-  if (!model || typeof model.selectedAtoms !== 'function') return;
-  try {
-    model.selectedAtoms({}).slice(0, 500).forEach((atom, index) => {
-      const label = `${atom.elem || atom.atom || 'X'}${index + 1}`;
-      state.viewer.addLabel(label, {
-        position: { x: atom.x, y: atom.y, z: atom.z },
-        fontSize: clamp(Math.round(state.gui.labelSize / 3), 8, 24),
-        fontColor: '#111820',
-        backgroundColor: 'rgba(255,255,255,0.78)',
-        backgroundOpacity: 0.72,
-        borderThickness: 0.4,
-        borderColor: '#d8e0e6'
-      });
-    });
-  } catch (error) {
-    setStatus('Label skipped', false);
   }
 }
 
@@ -733,6 +1543,11 @@ function syncOrientationView() {
   const baseView = state.orientationBaseView || state.orientationViewer.getView().slice(0, 4);
   state.orientationViewer.setView([...baseView, ...mainView.slice(4, 8)]);
   state.orientationViewer.render();
+}
+
+function syncSceneOverlays() {
+  syncOrientationView();
+  updateBondAnnotationPositions();
 }
 
 function syncAxesControls() {
@@ -799,6 +1614,8 @@ function addCubeLayer(layer) {
         color: colorVolume ? undefined : solidColor
       };
       const addIsosurface = (spec) => {
+        startupMetrics.totalIsosurfaceCalls = (startupMetrics.totalIsosurfaceCalls || 0) + 1;
+        if (els.viewer) els.viewer.dataset.isosurfaceCalls = String(startupMetrics.totalIsosurfaceCalls);
         if (!startupMetrics.ready) {
           startupMetrics.initialIsosurfaceCalls = (startupMetrics.initialIsosurfaceCalls || 0) + 1;
         }
@@ -838,18 +1655,20 @@ function renderScene(zoom = false) {
   if (!startupMetrics.ready) startupMetrics.initialSceneRenders = (startupMetrics.initialSceneRenders || 0) + 1;
 
   state.orbitalShapes.clear();
+  resetAtomDecorationReferences();
   state.viewer.clear();
   applySceneStyle();
-  addStructureToViewer();
+  const structureModel = addStructureToViewer();
   state.layers.filter((layer) => layer.visible).forEach(addCubeLayer);
   drawCellBox();
+  renderAtomSelectionDecorations(structureModel);
 
   if (zoom || state.dirtyZoom) {
     state.viewer.zoomTo();
     state.dirtyZoom = false;
   }
   state.viewer.render();
-  syncOrientationView();
+  syncSceneOverlays();
   updateLabels();
   updateStats();
   syncMultiwfnGuiControls();
@@ -1334,21 +2153,11 @@ function setStyleMenuOpen(open, options = {}) {
 
 function setGuiOrbitalRequestBusy(busy) {
   state.gui.orbitalRequestBusy = Boolean(busy);
-  [
-    els.guiOrbitalSelect,
-    els.guiOrbitalInput,
-    els.guiOrbitalIsovalue,
-    els.guiOrbitalIsovalueNumber,
-    els.guiOrbPrev,
-    els.guiOrbNext,
-    els.guiMenuQuality
-  ].forEach((control) => {
-    if (control) control.disabled = state.gui.orbitalRequestBusy;
-  });
+  syncBackendRequestControls();
 }
 
 async function requestGuiOrbital(index, options = {}) {
-  if (state.gui.orbitalRequestBusy) return;
+  if (state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy) return;
   const orbitalIndex = Number(index) || 0;
   els.guiOrbitalInput.value = String(orbitalIndex);
   if (orbitalIndex <= 0) {
@@ -1465,7 +2274,9 @@ function initializeMultiwfnOrbitalSelection() {
   });
 }
 
-function setStructureData(text, name = 'structure.xyz', format = 'xyz') {
+function setStructureData(text, name = 'structure.xyz', format = 'xyz', options = {}) {
+  clearAtomSelectionState();
+  clearBondAnalysisState({ resetCapabilities: !options.preserveBondCapabilities });
   const normalizedFormat = format === 'auto' ? detectFormat(name) : format;
   state.structure = {
     data: text,
@@ -1484,6 +2295,8 @@ function loadStructure(text, name = 'structure.xyz', format = 'xyz') {
 }
 
 function clearStructure() {
+  clearAtomSelectionState();
+  clearBondAnalysisState({ resetCapabilities: true });
   state.structure = { data: '', name: '', format: 'xyz', atoms: 0, baseData: '' };
   state.dirtyZoom = true;
   setStatus('Structure cleared');
@@ -1670,7 +2483,9 @@ async function setManifestStructure(structureEntry, baseUrl) {
   if (!structureEntry) return false;
   const structureData = await loadTextFromManifestEntry(structureEntry, baseUrl);
   const name = structureEntry.name || structureEntry.path || structureEntry.url || 'structure';
-  setStructureData(structureData, name, structureEntry.format || detectFormat(name));
+  setStructureData(structureData, name, structureEntry.format || detectFormat(name), {
+    preserveBondCapabilities: true
+  });
   return true;
 }
 
@@ -1747,7 +2562,45 @@ async function loadBatchManifest(structureEntry, specs, baseUrl) {
   finishStartup();
 }
 
+function normalizeBondAnalysisCapabilities(source) {
+  const normalized = defaultBondAnalysisCapabilities();
+  if (!source || typeof source !== 'object') return normalized;
+  normalized.periodicSupported = Boolean(source.periodicSupported);
+  normalized.openShell = Boolean(source.openShell);
+  bondPropertyDefinitions.filter((property) => property.backend).forEach((property) => {
+    const incoming = source.methods?.[property.id];
+    if (typeof incoming === 'boolean') {
+      normalized.methods[property.id] = {
+        available: incoming,
+        reason: incoming ? '' : 'This bond-order method is unavailable for the current wavefunction'
+      };
+    } else if (incoming && typeof incoming === 'object') {
+      normalized.methods[property.id] = {
+        available: Boolean(incoming.available),
+        reason: String(incoming.reason || 'This bond-order method is unavailable for the current wavefunction')
+      };
+    }
+  });
+  return normalized;
+}
+
+function refreshBondAnalysisCapabilities() {
+  const base = state.bondAnalysis.baseCapabilities || defaultBondAnalysisCapabilities();
+  const periodicBlocked = Boolean(state.periodic.enabled && !base.periodicSupported);
+  state.bondAnalysis.capabilities = {
+    periodicSupported: Boolean(base.periodicSupported),
+    openShell: Boolean(base.openShell),
+    methods: Object.fromEntries(Object.entries(base.methods || {}).map(([method, capability]) => [
+      method,
+      periodicBlocked
+        ? { available: false, reason: 'Periodic bond-order calculations are not supported in this GUI' }
+        : { available: Boolean(capability.available), reason: String(capability.reason || '') }
+    ]))
+  };
+}
+
 async function loadManifestObject(manifest, baseUrl = '') {
+  state.bondAnalysis.baseCapabilities = normalizeBondAnalysisCapabilities(manifest.bondAnalysis);
   if (manifest.multiwfnGui) {
     state.multiwfnGui = {
       entry: manifest.multiwfnGui.entry || 'standalone',
@@ -1797,6 +2650,7 @@ async function loadManifestObject(manifest, baseUrl = '') {
     els.structureRepeatMode.value = state.periodic.repeatMode || 'range';
     els.cubeRepeatCap.value = state.periodic.cubeRepeatCap || 8;
   }
+  refreshBondAnalysisCapabilities();
 
   const structureEntry = manifest.structure;
   const layerEntries = manifest.cubes || manifest.layers || [];
@@ -1825,6 +2679,7 @@ function saveManifest() {
     format: 'multiwfn-3dmol-workbench',
     version: 1,
     multiwfnGui: state.multiwfnGui,
+    bondAnalysis: state.bondAnalysis.capabilities,
     structure: state.structure.name
       ? {
           name: state.structure.name,
@@ -1884,6 +2739,7 @@ function savePng() {
 function showPlotPanel(show = true) {
   els.plotPanel.classList.toggle('is-hidden', !show);
   updateOrientationVisibility();
+  updateBondAnnotationPositions();
 }
 
 function plotLayout(title) {
@@ -2390,7 +3246,7 @@ function rotateGuiView(direction) {
   if (direction === 'left') state.viewer.rotate(-angle, 'y');
   if (direction === 'right') state.viewer.rotate(angle, 'y');
   state.viewer.render();
-  syncOrientationView();
+  syncSceneOverlays();
 }
 
 function resetGuiView() {
@@ -2421,7 +3277,7 @@ function resetGuiView() {
   state.viewer.setView(resetView);
   state.dirtyZoom = false;
   state.viewer.render();
-  syncOrientationView();
+  syncSceneOverlays();
   setStatus('View reset');
 }
 
@@ -2478,6 +3334,30 @@ function bindTabs() {
 
 function bindEvents() {
   bindTabs();
+
+  [els.bondContextMenu, els.bondContextSubmenu].forEach((menu) => {
+    menu.addEventListener('keydown', handleBondMenuKeydown);
+  });
+  document.addEventListener('click', (event) => {
+    const menuOpen = !els.bondContextMenu.hidden || !els.bondContextSubmenu.hidden;
+    if (menuOpen && !els.bondContextMenu.contains(event.target) && !els.bondContextSubmenu.contains(event.target)) {
+      closeBondContextMenu();
+    }
+  });
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    if (!els.bondContextSubmenu.hidden) {
+      closeBondSubmenu({ focus: true });
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    if (!els.bondContextMenu.hidden) {
+      closeBondContextMenu();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  });
 
   document.querySelectorAll('.gui-mode').forEach((button) => {
     button.addEventListener('click', () => activateGuiMode(button.dataset.guiMode));
@@ -2822,6 +3702,9 @@ function cacheElements() {
   Object.assign(els, {
     viewer: byId('viewer'),
     viewerWrap: document.querySelector('.viewport-wrap'),
+    bondAnnotationLayer: byId('bond-annotation-layer'),
+    bondContextMenu: byId('bond-context-menu'),
+    bondContextSubmenu: byId('bond-context-submenu'),
     orientationWidget: byId('orientation-widget'),
     plotPanel: byId('plot-panel'),
     plotView: byId('plot-view'),
@@ -2997,10 +3880,11 @@ async function init() {
     backgroundColor: backgrounds.white.viewer,
     antialias: true
   });
+  state.viewer.userContextMenuHandler = handleAtomContextMenu;
   initializeOrientationViewer();
   markStartup('viewerCreatedAt');
   if (typeof state.viewer.setViewChangeCallback === 'function') {
-    state.viewer.setViewChangeCallback(syncOrientationView);
+    state.viewer.setViewChangeCallback(syncSceneOverlays);
   }
 
   bindEvents();
@@ -3033,5 +3917,7 @@ window.addEventListener('resize', () => {
   state.viewer.resize();
   state.viewer.render();
   updateOrientationVisibility();
+  updateBondAnnotationPositions();
+  closeBondContextMenu();
   repositionOpenStyleSubmenu();
 });

--- a/frontend/3dmol-viewer/index.html
+++ b/frontend/3dmol-viewer/index.html
@@ -711,6 +711,9 @@
 
       <section class="viewport-wrap" aria-label="3D viewer">
         <div id="viewer"></div>
+        <div id="bond-annotation-layer" class="bond-annotation-layer" aria-live="polite"></div>
+        <div id="bond-context-menu" class="bond-context-menu" role="menu" aria-label="Selected bonds" hidden></div>
+        <div id="bond-context-submenu" class="bond-context-menu bond-context-submenu" role="menu" aria-label="Bond properties" hidden></div>
         <div id="orientation-widget" class="orientation-widget" aria-label="Orientation axes"></div>
         <div id="plot-panel" class="plot-panel is-hidden" aria-label="2D plot">
           <div id="plot-view"></div>

--- a/frontend/3dmol-viewer/styles.css
+++ b/frontend/3dmol-viewer/styles.css
@@ -508,6 +508,154 @@ button:hover {
   inset: 0;
 }
 
+.bond-annotation-layer {
+  position: absolute;
+  z-index: 4;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bond-annotation {
+  position: absolute;
+  width: max-content;
+  min-width: 132px;
+  max-width: min(250px, calc(100% - 16px));
+  padding: 5px 25px 5px 7px;
+  color: #111820;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid #8c969c;
+  border-radius: 3px;
+  box-shadow: 1px 2px 6px rgba(0, 0, 0, 0.20);
+  font: 12px/1.25 "Consolas", "Courier New", monospace;
+  pointer-events: auto;
+}
+
+.bond-annotation[hidden],
+.bond-annotation-layer[hidden] {
+  display: none;
+}
+
+.bond-annotation-title {
+  margin-bottom: 3px;
+  font-weight: 700;
+}
+
+.bond-annotation-values {
+  display: grid;
+  gap: 1px;
+}
+
+.bond-annotation-row {
+  overflow-wrap: anywhere;
+}
+
+.bond-annotation-row.is-pending {
+  color: #56646b;
+}
+
+.bond-annotation-close {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0;
+  color: #29343a;
+  background: transparent;
+  border: 0;
+  border-radius: 2px;
+  font: 700 13px/1 system-ui, sans-serif;
+}
+
+.bond-annotation-close:hover {
+  color: #000;
+  background: #d8e7ff;
+}
+
+.bond-context-menu {
+  position: absolute;
+  z-index: 20;
+  width: max-content;
+  min-width: 196px;
+  max-width: min(280px, calc(100% - 16px));
+  max-height: calc(100% - 16px);
+  padding: 2px;
+  overflow: auto;
+  color: #000;
+  background: #f5f4e9;
+  border: 1px solid #777;
+  border-radius: 2px;
+  box-shadow: 2px 3px 8px rgba(0, 0, 0, 0.24);
+  font: 14px/1.2 "Times New Roman", Times, serif;
+}
+
+.bond-context-menu[hidden] {
+  display: none;
+}
+
+.bond-context-heading {
+  padding: 5px 7px 4px;
+  color: #3d464b;
+  font-weight: 700;
+}
+
+.bond-context-menu button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  min-height: 28px;
+  padding: 4px 7px;
+  color: #000;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  text-align: left;
+}
+
+.bond-context-menu button:hover,
+.bond-context-menu button:focus-visible,
+.bond-context-menu button[aria-expanded="true"] {
+  color: #000;
+  background: #d8e7ff;
+}
+
+.bond-context-menu button:disabled {
+  color: #777;
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.bond-context-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.bond-context-value {
+  color: #3e535d;
+  font: 12px/1.1 "Consolas", "Courier New", monospace;
+  white-space: nowrap;
+}
+
+.bond-context-reason {
+  display: block;
+  margin-top: 1px;
+  color: #777;
+  font: 11px/1.15 "Times New Roman", Times, serif;
+}
+
+.bond-context-separator {
+  height: 1px;
+  margin: 2px 4px;
+  background: #aaa;
+}
+
 .orientation-widget {
   position: absolute;
   z-index: 2;

--- a/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
+++ b/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
@@ -62,11 +62,15 @@ except Exception:  # pragma: no cover - depends on optional runtime package
 QT_IMPORTED_AT = time.perf_counter()
 
 
-ORBITAL_REQUEST_LOCK = threading.Lock()
-ORBITAL_REQUEST_CONSUME_TIMEOUT = 5.0
+BACKEND_REQUEST_LOCK = threading.Lock()
+BACKEND_REQUEST_CONSUME_TIMEOUT = 5.0
 ORBITAL_REQUEST_TIMEOUT = 300.0
-ORBITAL_REQUEST_POLL_INTERVAL = 0.2
+BOND_REQUEST_TIMEOUT = 300.0
+FBO_REQUEST_TIMEOUT = 900.0
+BACKEND_REQUEST_POLL_INTERVAL = 0.2
 MAX_DYNAMIC_ORBITAL_CUBES = 12
+BOND_METHODS = frozenset(("mayer", "gwbo", "wiberg_lowdin", "mulliken", "fbo"))
+LAST_REQUEST_ID = 0
 BACKEND_UNAVAILABLE_MESSAGE = (
     "Multiwfn backend unavailable; restart visualization from menu 0 and keep the terminal open"
 )
@@ -130,31 +134,38 @@ def prune_dynamic_orbital_cubes(session_dir: Path, keep: int = MAX_DYNAMIC_ORBIT
             pass
 
 
-def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
-    with ORBITAL_REQUEST_LOCK:
+def next_request_id() -> int:
+    global LAST_REQUEST_ID
+    LAST_REQUEST_ID = max(int(time.time() * 1000), LAST_REQUEST_ID + 1)
+    return LAST_REQUEST_ID
+
+
+def request_backend(
+    session_dir: Path,
+    request_payload: str,
+    *,
+    timeout: float,
+    timeout_message: str,
+) -> dict:
+    with BACKEND_REQUEST_LOCK:
         stop = session_dir / "gui_stop.flag"
         if stop.is_file():
             return {"ok": False, "message": BACKEND_UNAVAILABLE_MESSAGE}
 
-        reqid = int(time.time() * 1000)
-        index = int(query.get("index", ["0"])[0] or 0)
-        quality = int(query.get("quality", ["0"])[0] or 0)
-        isovalue = float(query.get("isovalue", ["0.0"])[0] or 0.0)
+        reqid = next_request_id()
         response = session_dir / f"response_{reqid}.json"
         request = session_dir / "gui_request.txt"
         if response.exists():
             response.unlink()
-        request.write_text(f"{reqid} orbital {index} {quality} {isovalue:.10g}\n", encoding="utf-8")
+        request.write_text(f"{reqid} {request_payload}\n", encoding="utf-8")
 
         consumed = False
-        consume_deadline = time.monotonic() + ORBITAL_REQUEST_CONSUME_TIMEOUT
-        deadline = time.monotonic() + ORBITAL_REQUEST_TIMEOUT
+        consume_deadline = time.monotonic() + BACKEND_REQUEST_CONSUME_TIMEOUT
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if response.is_file():
                 try:
-                    payload = json.loads(response.read_text(encoding="utf-8"))
-                    prune_dynamic_orbital_cubes(session_dir)
-                    return payload
+                    return json.loads(response.read_text(encoding="utf-8"))
                 except (OSError, json.JSONDecodeError):
                     pass
 
@@ -175,11 +186,46 @@ def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
                         except FileNotFoundError:
                             pass
                         return {"ok": False, "message": BACKEND_UNAVAILABLE_MESSAGE}
-                    return {"ok": False, "message": "Orbital request was superseded; try again"}
+                    return {"ok": False, "message": "Backend request was superseded; try again"}
 
-            time.sleep(ORBITAL_REQUEST_POLL_INTERVAL)
+            time.sleep(BACKEND_REQUEST_POLL_INTERVAL)
 
-        return {"ok": False, "message": "Timed out waiting for Multiwfn orbital grid"}
+        return {"ok": False, "message": timeout_message}
+
+
+def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    index = int(query.get("index", ["0"])[0] or 0)
+    quality = int(query.get("quality", ["0"])[0] or 0)
+    isovalue = float(query.get("isovalue", ["0.0"])[0] or 0.0)
+    payload = request_backend(
+        session_dir,
+        f"orbital {index} {quality} {isovalue:.10g}",
+        timeout=ORBITAL_REQUEST_TIMEOUT,
+        timeout_message="Timed out waiting for Multiwfn orbital grid",
+    )
+    if payload.get("ok"):
+        prune_dynamic_orbital_cubes(session_dir)
+    return payload
+
+
+def request_bond(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    try:
+        atom1 = int(query.get("atom1", ["0"])[0] or 0)
+        atom2 = int(query.get("atom2", ["0"])[0] or 0)
+    except ValueError:
+        return {"ok": False, "message": "Atom indices must be integers"}
+    method = str(query.get("method", [""])[0] or "").strip().lower()
+    if atom1 <= 0 or atom2 <= 0 or atom1 == atom2:
+        return {"ok": False, "message": "Two distinct positive atom indices are required"}
+    if method not in BOND_METHODS:
+        return {"ok": False, "message": "Unsupported bond-order method"}
+    timeout = FBO_REQUEST_TIMEOUT if method == "fbo" else BOND_REQUEST_TIMEOUT
+    return request_backend(
+        session_dir,
+        f"bond {atom1} {atom2} {method}",
+        timeout=timeout,
+        timeout_message=f"Timed out waiting for Multiwfn {method} calculation",
+    )
 
 
 class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
@@ -221,6 +267,12 @@ def make_handler(frontend_dir: Path, session_dir: Path, manifest: Path):
             if request_path == "/api/orbital":
                 try:
                     send_json(self, request_orbital(session_dir, query))
+                except Exception as exc:
+                    send_json(self, {"ok": False, "message": str(exc)}, status=500)
+                return
+            if request_path == "/api/bond":
+                try:
+                    send_json(self, request_bond(session_dir, query))
                 except Exception as exc:
                     send_json(self, {"ok": False, "message": str(exc)}, status=500)
                 return

--- a/noGUI/GUI_3dmol.f90
+++ b/noGUI/GUI_3dmol.f90
@@ -6,6 +6,8 @@ real*8 :: aug3D_main0=6D0
 integer,allocatable :: gui_orbital_indices(:)
 integer :: gui_orbital_count=0
 logical :: gui_has_cubmat_file=.false.,gui_has_cubmattmp_file=.false.
+real*8,allocatable :: gui_fbo_cache(:,:)
+logical :: gui_fbo_ready=.false.
 
 contains
 
@@ -90,6 +92,7 @@ real*8,intent(in) :: init1,end1,init2,end2,init3,end3
 character(len=512) :: session,manifest,cmd
 
 call reset_generated_orbitals()
+call reset_bond_analysis_cache()
 gui_has_cubmat_file=.false.
 gui_has_cubmattmp_file=.false.
 call get_session_dir(session)
@@ -123,6 +126,11 @@ subroutine reset_generated_orbitals()
 if (allocated(gui_orbital_indices)) deallocate(gui_orbital_indices)
 allocate(gui_orbital_indices(0))
 gui_orbital_count=0
+end subroutine
+
+subroutine reset_bond_analysis_cache()
+if (allocated(gui_fbo_cache)) deallocate(gui_fbo_cache)
+gui_fbo_ready=.false.
 end subroutine
 
 subroutine get_session_dir(session)
@@ -275,9 +283,9 @@ end subroutine
 
 subroutine run_3dmol_gui_loop(session)
 character(len=*),intent(in) :: session
-character(len=512) :: reqfile,stopfile,respfile
-character(len=32) :: action
-integer :: iu,istat,iorb,quality
+character(len=1024) :: reqfile,stopfile,respfile,line
+character(len=32) :: action,method
+integer :: iu,istat,iorb,quality,iatm1,iatm2
 integer*8 :: reqid,lastid
 real*8 :: isoval
 logical :: alive
@@ -293,11 +301,28 @@ do
     if (alive) then
         open(newunit=iu,file=trim(reqfile),status="old",action="read",iostat=istat)
         if (istat==0) then
-            read(iu,*,iostat=istat) reqid,action,iorb,quality,isoval
+            read(iu,"(a)",iostat=istat) line
             close(iu,status="delete")
+            if (istat==0) read(line,*,iostat=istat) reqid,action
             if (istat==0.and.reqid/=lastid) then
                 write(respfile,"(a,'/response_',i0,'.json')") trim(session),reqid
-                if (trim(action)=="orbital") call handle_orbital_request(trim(session),trim(respfile),iorb,quality,isoval)
+                if (trim(action)=="orbital") then
+                    read(line,*,iostat=istat) reqid,action,iorb,quality,isoval
+                    if (istat==0) then
+                        call handle_orbital_request(trim(session),trim(respfile),iorb,quality,isoval)
+                    else
+                        call write_gui_json_error(trim(respfile),"Malformed orbital request")
+                    end if
+                else if (trim(action)=="bond") then
+                    read(line,*,iostat=istat) reqid,action,iatm1,iatm2,method
+                    if (istat==0) then
+                        call handle_bond_request(trim(respfile),iatm1,iatm2,trim(method))
+                    else
+                        call write_gui_json_error(trim(respfile),"Malformed bond request")
+                    end if
+                else
+                    call write_gui_json_error(trim(respfile),"Unknown GUI request")
+                end if
                 lastid=reqid
             end if
         end if
@@ -363,6 +388,113 @@ write(iu,"(a,1pe16.8,a)") '    "isovalue": ',sur_value_orb,','
 write(iu,"(a)") '    "visible": true'
 write(iu,"(a)") '  }'
 write(iu,"(a)") "}"
+close(iu)
+end subroutine
+
+subroutine handle_bond_request(respfile,iatm1,iatm2,method)
+character(len=*),intent(in) :: respfile,method
+integer,intent(in) :: iatm1,iatm2
+integer :: iu,ierror,radpot_org,sphpot_org
+real*8 :: value,total,alpha,beta,mixed
+logical :: openshell
+
+if (iatm1<1.or.iatm1>ncenter.or.iatm2<1.or.iatm2>ncenter.or.iatm1==iatm2) then
+    call write_gui_json_error(respfile,"Invalid atom indices")
+    return
+end if
+if (ifPBC>0) then
+    call write_gui_json_error(respfile,"Periodic bond-order calculations are not supported")
+    return
+end if
+
+openshell=wfntype==1.or.wfntype==2.or.wfntype==4
+total=0D0
+alpha=0D0
+beta=0D0
+mixed=0D0
+ierror=0
+
+if (method=="mayer".or.method=="gwbo") then
+    call calc_bond_pair_mayer(iatm1,iatm2,total,alpha,beta,mixed,ierror)
+    if (method=="gwbo".and..not.openshell) then
+        call write_gui_json_error(respfile,"GWBO is only distinct for open-shell wavefunctions")
+        return
+    end if
+    if (method=="gwbo") then
+        value=mixed
+    else
+        value=total
+    end if
+else if (method=="wiberg_lowdin") then
+    call calc_bond_pair_lowdin(iatm1,iatm2,total,alpha,beta,mixed,ierror)
+    value=total
+else if (method=="mulliken") then
+    call calc_bond_pair_mulliken(iatm1,iatm2,total,alpha,beta,ierror)
+    mixed=total
+    value=total
+else if (method=="fbo") then
+    if (.not.allocated(b).or..not.allocated(CObasa)) then
+        call write_gui_json_error(respfile,"GTF wavefunction information is unavailable")
+        return
+    end if
+    if (.not.gui_fbo_ready) then
+        radpot_org=radpot
+        sphpot_org=sphpot
+        call fuzzyana(11)
+        radpot=radpot_org
+        sphpot=sphpot_org
+        if (.not.allocated(bndordmat)) then
+            call write_gui_json_error(respfile,"FBO calculation did not return a result")
+            return
+        end if
+        if (allocated(gui_fbo_cache)) deallocate(gui_fbo_cache)
+        allocate(gui_fbo_cache(ncenter,ncenter))
+        gui_fbo_cache=bndordmat
+        gui_fbo_ready=.true.
+    end if
+    value=gui_fbo_cache(iatm1,iatm2)
+    total=value
+else
+    call write_gui_json_error(respfile,"Unsupported bond-order method")
+    return
+end if
+
+if (ierror/=0) then
+    if (ierror==3) then
+        call write_gui_json_error(respfile,"Selected atom has no basis functions")
+    else
+        call write_gui_json_error(respfile,"Basis-function and density information is unavailable")
+    end if
+    return
+end if
+
+open(newunit=iu,file=trim(respfile),status="replace",action="write")
+write(iu,"(a)") "{"
+write(iu,"(a)") '  "ok": true,'
+write(iu,"(a,i0,a,i0,a)") '  "bond": { "atom1": ',iatm1,', "atom2": ',iatm2,' },'
+write(iu,"(a,a,a)") '  "method": "',trim(method),'",'
+write(iu,"(a,es24.16,a)") '  "value": ',value,','
+if (openshell.and.(method=="mayer".or.method=="gwbo")) then
+    write(iu,"(a,es24.16,a,es24.16,a,es24.16,a,es24.16,a)") &
+        '  "components": { "alpha": ',alpha,', "beta": ',beta,', "total": ',total,', "gwbo": ',mixed,' }'
+else if (openshell.and.method=="wiberg_lowdin") then
+    write(iu,"(a,es24.16,a,es24.16,a,es24.16,a,es24.16,a)") &
+        '  "components": { "alpha": ',alpha,', "beta": ',beta,', "total": ',total,', "mixed": ',mixed,' }'
+else if (openshell.and.method=="mulliken") then
+    write(iu,"(a,es24.16,a,es24.16,a,es24.16,a)") &
+        '  "components": { "alpha": ',alpha,', "beta": ',beta,', "total": ',total,' }'
+else
+    write(iu,"(a,es24.16,a)") '  "components": { "total": ',total,' }'
+end if
+write(iu,"(a)") "}"
+close(iu)
+end subroutine
+
+subroutine write_gui_json_error(respfile,message)
+character(len=*),intent(in) :: respfile,message
+integer :: iu
+open(newunit=iu,file=trim(respfile),status="replace",action="write")
+write(iu,"(a,a,a)") '{ "ok": false, "message": "',trim(message),'" }'
 close(iu)
 end subroutine
 
@@ -642,6 +774,7 @@ if (allocated(a).and.ncenter>0) then
 else
     write(iu,"(a)") '  "structure": null,'
 end if
+call write_bond_analysis_manifest(iu)
 if (ifPBC>0) then
     write(iu,"(a)") '  "periodic": {'
     write(iu,"(a)") '    "enabled": true,'
@@ -666,6 +799,56 @@ call write_orbital_cube_manifest(iu,ncube)
 write(iu,"(a)") '  ]'
 write(iu,"(a)") "}"
 close(iu)
+end subroutine
+
+subroutine write_bond_analysis_manifest(iu)
+integer,intent(in) :: iu
+logical :: basisok,fbook,openshell
+character(len=96) :: basisreason,fboreason,gwreason
+
+openshell=wfntype==1.or.wfntype==2.or.wfntype==4
+basisok=ifPBC==0.and.allocated(CObasa).and.allocated(Ptot).and.allocated(Sbas).and. &
+    allocated(basstart).and.allocated(basend)
+fbook=ifPBC==0.and.allocated(b).and.allocated(CObasa).and.allocated(Ptot)
+if (ifPBC>0) then
+    basisreason="Periodic bond-order calculations are not supported in this GUI"
+    fboreason=basisreason
+else
+    basisreason="Basis-function and density information is unavailable"
+    fboreason="GTF wavefunction information is unavailable"
+end if
+if (openshell) then
+    gwreason=basisreason
+else
+    gwreason="GWBO is only distinct for open-shell wavefunctions"
+end if
+
+write(iu,"(a)") '  "bondAnalysis": {'
+write(iu,"(a)") '    "periodicSupported": false,'
+write(iu,"(a,a,a)") '    "openShell": ',trim(json_bool(openshell)),','
+write(iu,"(a)") '    "methods": {'
+call write_bond_method_capability(iu,"mayer",basisok,basisreason,.true.)
+call write_bond_method_capability(iu,"gwbo",basisok.and.openshell,gwreason,.true.)
+call write_bond_method_capability(iu,"wiberg_lowdin",basisok,basisreason,.true.)
+call write_bond_method_capability(iu,"mulliken",basisok,basisreason,.true.)
+call write_bond_method_capability(iu,"fbo",fbook,fboreason,.false.)
+write(iu,"(a)") '    }'
+write(iu,"(a)") '  },'
+end subroutine
+
+subroutine write_bond_method_capability(iu,method,available,reason,appendcomma)
+integer,intent(in) :: iu
+character(len=*),intent(in) :: method,reason
+logical,intent(in) :: available,appendcomma
+character(len=1) :: comma
+
+comma=" "
+if (appendcomma) comma=","
+if (available) then
+    write(iu,"(a,a,a,a)") '      "',trim(method),'": { "available": true }',comma
+else
+    write(iu,"(a,a,a,a,a,a)") '      "',trim(method),'": { "available": false, "reason": "',trim(reason),'" }',comma
+end if
 end subroutine
 
 subroutine write_cube_entry(iu,ncube,name,path,role,orbidx,isoval)

--- a/tools/multiwfn_3dmol_server.py
+++ b/tools/multiwfn_3dmol_server.py
@@ -20,11 +20,15 @@ import urllib.parse
 import webbrowser
 
 
-ORBITAL_REQUEST_LOCK = threading.Lock()
-ORBITAL_REQUEST_CONSUME_TIMEOUT = 5.0
+BACKEND_REQUEST_LOCK = threading.Lock()
+BACKEND_REQUEST_CONSUME_TIMEOUT = 5.0
 ORBITAL_REQUEST_TIMEOUT = 300.0
-ORBITAL_REQUEST_POLL_INTERVAL = 0.2
+BOND_REQUEST_TIMEOUT = 300.0
+FBO_REQUEST_TIMEOUT = 900.0
+BACKEND_REQUEST_POLL_INTERVAL = 0.2
 MAX_DYNAMIC_ORBITAL_CUBES = 12
+BOND_METHODS = frozenset(("mayer", "gwbo", "wiberg_lowdin", "mulliken", "fbo"))
+LAST_REQUEST_ID = 0
 BACKEND_UNAVAILABLE_MESSAGE = (
     "Multiwfn backend unavailable; restart visualization from menu 0 and keep the terminal open"
 )
@@ -92,31 +96,38 @@ def prune_dynamic_orbital_cubes(session_dir: Path, keep: int = MAX_DYNAMIC_ORBIT
             pass
 
 
-def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
-    with ORBITAL_REQUEST_LOCK:
+def next_request_id() -> int:
+    global LAST_REQUEST_ID
+    LAST_REQUEST_ID = max(int(time.time() * 1000), LAST_REQUEST_ID + 1)
+    return LAST_REQUEST_ID
+
+
+def request_backend(
+    session_dir: Path,
+    request_payload: str,
+    *,
+    timeout: float,
+    timeout_message: str,
+) -> dict:
+    with BACKEND_REQUEST_LOCK:
         stop = session_dir / "gui_stop.flag"
         if stop.is_file():
             return {"ok": False, "message": BACKEND_UNAVAILABLE_MESSAGE}
 
-        reqid = int(time.time() * 1000)
-        index = int(query.get("index", ["0"])[0] or 0)
-        quality = int(query.get("quality", ["0"])[0] or 0)
-        isovalue = float(query.get("isovalue", ["0.0"])[0] or 0.0)
+        reqid = next_request_id()
         response = session_dir / f"response_{reqid}.json"
         request = session_dir / "gui_request.txt"
         if response.exists():
             response.unlink()
-        request.write_text(f"{reqid} orbital {index} {quality} {isovalue:.10g}\n", encoding="utf-8")
+        request.write_text(f"{reqid} {request_payload}\n", encoding="utf-8")
 
         consumed = False
-        consume_deadline = time.monotonic() + ORBITAL_REQUEST_CONSUME_TIMEOUT
-        deadline = time.monotonic() + ORBITAL_REQUEST_TIMEOUT
+        consume_deadline = time.monotonic() + BACKEND_REQUEST_CONSUME_TIMEOUT
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if response.is_file():
                 try:
-                    payload = json.loads(response.read_text(encoding="utf-8"))
-                    prune_dynamic_orbital_cubes(session_dir)
-                    return payload
+                    return json.loads(response.read_text(encoding="utf-8"))
                 except (OSError, json.JSONDecodeError):
                     pass
 
@@ -137,11 +148,46 @@ def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
                         except FileNotFoundError:
                             pass
                         return {"ok": False, "message": BACKEND_UNAVAILABLE_MESSAGE}
-                    return {"ok": False, "message": "Orbital request was superseded; try again"}
+                    return {"ok": False, "message": "Backend request was superseded; try again"}
 
-            time.sleep(ORBITAL_REQUEST_POLL_INTERVAL)
+            time.sleep(BACKEND_REQUEST_POLL_INTERVAL)
 
-        return {"ok": False, "message": "Timed out waiting for Multiwfn orbital grid"}
+        return {"ok": False, "message": timeout_message}
+
+
+def request_orbital(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    index = int(query.get("index", ["0"])[0] or 0)
+    quality = int(query.get("quality", ["0"])[0] or 0)
+    isovalue = float(query.get("isovalue", ["0.0"])[0] or 0.0)
+    payload = request_backend(
+        session_dir,
+        f"orbital {index} {quality} {isovalue:.10g}",
+        timeout=ORBITAL_REQUEST_TIMEOUT,
+        timeout_message="Timed out waiting for Multiwfn orbital grid",
+    )
+    if payload.get("ok"):
+        prune_dynamic_orbital_cubes(session_dir)
+    return payload
+
+
+def request_bond(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    try:
+        atom1 = int(query.get("atom1", ["0"])[0] or 0)
+        atom2 = int(query.get("atom2", ["0"])[0] or 0)
+    except ValueError:
+        return {"ok": False, "message": "Atom indices must be integers"}
+    method = str(query.get("method", [""])[0] or "").strip().lower()
+    if atom1 <= 0 or atom2 <= 0 or atom1 == atom2:
+        return {"ok": False, "message": "Two distinct positive atom indices are required"}
+    if method not in BOND_METHODS:
+        return {"ok": False, "message": "Unsupported bond-order method"}
+    timeout = FBO_REQUEST_TIMEOUT if method == "fbo" else BOND_REQUEST_TIMEOUT
+    return request_backend(
+        session_dir,
+        f"bond {atom1} {atom2} {method}",
+        timeout=timeout,
+        timeout_message=f"Timed out waiting for Multiwfn {method} calculation",
+    )
 
 
 def is_wsl() -> bool:
@@ -226,6 +272,13 @@ def make_handler(frontend_dir: Path, session_dir: Path, manifest: Path):
             if request_path == "/api/orbital":
                 try:
                     send_json(self, request_orbital(session_dir, query))
+                except Exception as exc:
+                    send_json(self, {"ok": False, "message": str(exc)}, status=500)
+                return
+
+            if request_path == "/api/bond":
+                try:
+                    send_json(self, request_bond(session_dir, query))
                 except Exception as exc:
                     send_json(self, {"ok": False, "message": str(exc)}, status=500)
                 return


### PR DESCRIPTION
## Summary

- identify bonds between selected atoms from 3Dmol's explicit bond topology
- add right-click bond property menus and persistent, camera-aware annotations
- calculate bond lengths locally and expose Mayer/GWBO, Lowdin-Wiberg, Mulliken, and FBO through the live Multiwfn backend
- serialize bond-order and orbital requests across both browser and Qt services
- advertise per-session method availability through the optional `bondAnalysis` manifest field

## Why

Atom multi-selection could highlight atoms, but it could not recognize selected bonds or inspect their properties. This adds an end-to-end path from the 3D viewer to Multiwfn's in-memory wavefunction while preserving the existing orbital session and avoiding unnecessary isosurface rebuilds.

## User impact

Right-clicking a selected atom now opens a menu for every adjacent selected bond. Results accumulate beside each bond, follow camera movement, survive orbital and display changes, and can be hidden or restored from cache independently. Periodic sessions remain length-only in this first version and explain why backend methods are unavailable.

## Validation

- compared benzene C1-C2 Mayer, Mulliken, Lowdin-Wiberg, and FBO values with Multiwfn's interactive menus; all agreed within `1e-6`
- verified open-shell alpha/beta and GWBO response components
- verified backend-unavailable handling in about 5 seconds and serialized orbital/bond requests
- completed real right-click tests in browser and Qt WebEngine
- checked 320 px, 480 px, and desktop layouts
- ran `node --check frontend/3dmol-viewer/app.js`
- ran Python bytecode compilation for both services
- checked duplicate HTML IDs and `git diff --check`
- built `build-qt-gui/Multiwfn_QtGUI` successfully
