### PR TITLE
Add structured issue report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
-name: Report an issue or propose a GUI change
-description: Report a build, packaging, runtime, reproducibility, or GUI issue
-title: "[Issue]: "
+name: Bug report
+description: Report a build, packaging, runtime, numerical, or GUI bug
+title: "[Bug]: "
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for helping improve the cross-platform Multiwfn build and GUI experiments.
-        Please provide enough detail to reproduce the issue or discuss the proposed change.
+        Please provide enough detail to reproduce the bug.
 
   - type: dropdown
     id: category
@@ -43,9 +43,9 @@ body:
       required: true
 
   - type: textarea
-    id: workflow
+    id: steps
     attributes:
-      label: Command or menu workflow
+      label: Steps to reproduce
       description: List the exact commands or Multiwfn menu path.
       placeholder: |
         1. Run ...
@@ -57,7 +57,7 @@ body:
   - type: textarea
     id: current-behavior
     attributes:
-      label: Current behavior or limitation
+      label: Current behavior
       description: Describe what currently happens and why it is a problem.
     validations:
       required: true
@@ -65,15 +65,15 @@ body:
   - type: textarea
     id: expected-behavior
     attributes:
-      label: Expected behavior or proposed change
-      description: Describe the expected result or the change you would like to discuss.
+      label: Expected behavior
+      description: Describe what should have happened instead.
     validations:
       required: true
 
   - type: textarea
     id: reproducer
     attributes:
-      label: Input type and reproducer
+      label: Input file and reproducer
       description: Provide the input file type and a small public reproducer when possible.
 
   - type: textarea
@@ -84,16 +84,10 @@ body:
       render: shell
 
   - type: textarea
-    id: evidence
+    id: screenshots
     attributes:
       label: Screenshots or comparisons
       description: Include screenshots, timings, numerical comparisons, or other supporting evidence.
-
-  - type: textarea
-    id: gui-scope
-    attributes:
-      label: GUI design scope
-      description: For GUI design changes or large refactors, describe the scope and the affected original Multiwfn workflow.
 
   - type: checkboxes
     id: checks
@@ -102,5 +96,5 @@ body:
       options:
         - label: I searched for an existing issue describing the same problem.
           required: true
-        - label: I have included enough information to reproduce or discuss the issue.
+        - label: I have included enough information to reproduce the issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Official Multiwfn forum
+    url: http://sobereva.com/wfnbbs/
+    about: For usage questions about Multiwfn wavefunction analysis workflows, please use the official forum.
+  - name: Upstream Multiwfn homepage
+    url: http://sobereva.com/multiwfn/
+    about: Official Multiwfn documentation and downloads maintained by the original author.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Propose a new feature, GUI enhancement, or documentation improvement
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to the cross-platform Multiwfn build and GUI project.
+        Please check that your idea is within scope of this fork (build infrastructure, GUI modernization, CI/CD)
+        and not a request to modify the upstream computational core.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - 3Dmol/Qt GUI
+        - Build or CI improvement
+        - Packaging or distribution
+        - Documentation
+        - Testing or benchmarking
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Describe the problem or use case that this feature would address.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Describe how you think this should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have considered.
+
+  - type: textarea
+    id: gui-scope
+    attributes:
+      label: GUI design scope
+      description: For GUI changes, describe the scope and the affected original Multiwfn workflow.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, references, or screenshots about the request.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for an existing issue describing the same feature.
+          required: true

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,24 @@
+name: Other
+description: General discussion or questions that don't fit the other templates
+title: "[Other]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for general discussions, questions, or topics that don't fit the bug report or feature request templates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your topic or question.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked that this doesn't fit the bug report or feature request template.
+          required: true

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -1,0 +1,100 @@
+name: Report an issue or propose a GUI change
+description: Report a build, packaging, runtime, reproducibility, or GUI issue
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the cross-platform Multiwfn build and GUI experiments.
+        Please provide enough detail to reproduce the issue or discuss the proposed change.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Build
+        - Packaging or dependencies
+        - Runtime
+        - Numerical reproducibility
+        - Tests, CI, or performance
+        - 3Dmol/Qt GUI
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      description: Include the OS name, version, and architecture.
+      placeholder: macOS 15.5, arm64
+    validations:
+      required: true
+
+  - type: input
+    id: tested-version
+    attributes:
+      label: Package or commit tested
+      description: Provide the release tag, package name, or commit SHA.
+      placeholder: v2026.6.2-nogui.4 or commit abc1234
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Command or menu workflow
+      description: List the exact commands or Multiwfn menu path.
+      placeholder: |
+        1. Run ...
+        2. Select menu ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior or limitation
+      description: Describe what currently happens and why it is a problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior or proposed change
+      description: Describe the expected result or the change you would like to discuss.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Input type and reproducer
+      description: Provide the input file type and a small public reproducer when possible.
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, or comparisons
+      description: Include relevant error output, screenshots, timings, or numerical comparisons.
+      render: shell
+
+  - type: textarea
+    id: gui-scope
+    attributes:
+      label: GUI design scope
+      description: For GUI design changes or large refactors, describe the scope and the affected original Multiwfn workflow.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched for an existing issue describing the same problem.
+          required: true
+        - label: I have included enough information to reproduce or discuss the issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -77,11 +77,17 @@ body:
       description: Provide the input file type and a small public reproducer when possible.
 
   - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Include relevant error output or terminal logs.
+      render: shell
+
+  - type: textarea
     id: evidence
     attributes:
-      label: Logs, screenshots, or comparisons
-      description: Include relevant error output, screenshots, timings, or numerical comparisons.
-      render: shell
+      label: Screenshots or comparisons
+      description: Include screenshots, timings, numerical comparisons, or other supporting evidence.
 
   - type: textarea
     id: gui-scope


### PR DESCRIPTION
## Summary

- add a GitHub Issue Form for build, packaging, runtime, reproducibility, testing, GUI, and documentation reports
- collect the operating system, tested package or commit, exact command or menu workflow, current behavior, and expected result requested by `CONTRIBUTING.md`
- include optional fields for public reproducers, logs, numerical comparisons, and GUI design scope
- require duplicate-search and reproducibility acknowledgements before submission

## Validation

- parsed the YAML successfully with Ruby Psych
- verified all form field IDs are unique
- ran `git diff --check`