### PR TITLE
Stage GUI runtime resources in CMake builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+/build-qt-gui/
 cmake-build-*/
 CMakeFiles/
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,62 @@ if(MULTIWFN_GUI_BACKEND STREQUAL "3dmol" AND MULTIWFN_3DMOL_DEFAULT_SHELL STREQU
   target_compile_definitions(${MULTIWFN_EXECUTABLE_NAME} PRIVATE MULTIWFN_3DMOL_DEFAULT_SHELL_QT)
 endif()
 
+if(MULTIWFN_GUI_BACKEND STREQUAL "3dmol")
+  find_package(Python3 QUIET COMPONENTS Interpreter)
+  if(NOT Python3_Interpreter_FOUND)
+    message(WARNING
+      "The 3Dmol development shell requires Python 3 at runtime. "
+      "Install Python 3 or provide an interpreter through MULTIWFN_3DMOL_PYTHON when launching."
+    )
+  elseif(MULTIWFN_3DMOL_DEFAULT_SHELL STREQUAL "qt")
+    execute_process(
+      COMMAND "${Python3_EXECUTABLE}" -c "import PyQt6; import PyQt6.QtWebEngineWidgets"
+      RESULT_VARIABLE _multiwfn_qt_python_status
+      OUTPUT_QUIET
+      ERROR_QUIET
+    )
+    if(NOT _multiwfn_qt_python_status EQUAL 0)
+      message(WARNING
+        "The Qt development shell requires PyQt6 and PyQt6-WebEngine for its embedded 3D viewer. "
+        "They were not importable with ${Python3_EXECUTABLE}; install them or configure "
+        "MULTIWFN_3DMOL_DEFAULT_SHELL=browser."
+      )
+    endif()
+  endif()
+
+  set(MULTIWFN_3DMOL_BUILD_RESOURCES "${CMAKE_CURRENT_BINARY_DIR}/resources")
+  add_custom_target(multiwfn_3dmol_resources ALL
+    COMMAND ${CMAKE_COMMAND} -E rm -rf
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/tools"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/3dmol-viewer"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/qt-multiwfn-gui"
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/tools"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_CURRENT_SOURCE_DIR}/settings.ini"
+      "${CMAKE_CURRENT_BINARY_DIR}/settings.ini"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_CURRENT_SOURCE_DIR}/tools/multiwfn_3dmol_server.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/tools/multiwfn_3dmol_file_dialog.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/tools/multiwfn_qt_gui.py"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/tools"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${CMAKE_CURRENT_SOURCE_DIR}/frontend/3dmol-viewer"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/3dmol-viewer"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${CMAKE_CURRENT_SOURCE_DIR}/frontend/qt-multiwfn-gui"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/qt-multiwfn-gui"
+    COMMAND ${CMAKE_COMMAND} -E rm -rf
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/tools/__pycache__"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/3dmol-viewer/__pycache__"
+      "${MULTIWFN_3DMOL_BUILD_RESOURCES}/frontend/qt-multiwfn-gui/__pycache__"
+    DEPENDS ${MULTIWFN_EXECUTABLE_NAME}
+    COMMENT "Staging Multiwfn settings and 3Dmol GUI runtime resources"
+    VERBATIM
+  )
+endif()
+
 if(WIN32)
   target_compile_definitions(${MULTIWFN_EXECUTABLE_NAME} PRIVATE MULTIWFN_WINDOWS)
   target_sources(${MULTIWFN_EXECUTABLE_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/Multiwfn.rc")

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,11 +4,10 @@ This repository keeps the original `Makefile` unchanged for the upstream
 Intel/Linux workflow and adds a minimal CMake path for reproducible noGUI
 builds.
 
-## Supported CMake Target
+## Supported CMake Targets
 
-The CMake build currently targets `Multiwfn_noGUI` only. This avoids DISLIN,
-Motif, X11, and OpenGL so CI can build on Linux, macOS, and Windows with GNU
-Fortran.
+The default CMake build targets `Multiwfn_noGUI`. This avoids DISLIN, Motif,
+X11, and OpenGL so CI can build on Linux, macOS, and Windows with GNU Fortran.
 
 The repository includes the upstream Multiwfn license terms in `LICENSE.txt`.
 Release assets must carry this file alongside the binaries.
@@ -18,9 +17,38 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel
 ```
 
-The GUI executable is intentionally not wired into CMake yet. Use the original
-`Makefile` for the upstream GUI build until the GUI dependency boundary is
-handled separately.
+The artifact-based 3Dmol GUI backend is also available through CMake. To build
+the native Qt shell by default:
+
+```sh
+cmake -S . -B build-qt-gui \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMULTIWFN_GUI_BACKEND=3dmol \
+  -DMULTIWFN_3DMOL_DEFAULT_SHELL=qt
+cmake --build build-qt-gui --parallel
+```
+
+This produces `Multiwfn_QtGUI`, copies `settings.ini` beside the executable,
+and stages its Python launchers plus web frontend under
+`build-qt-gui/resources/`. This is a development build layout, not a
+self-contained release package. The executable can be run directly from the
+build directory when its development runtime dependencies are available.
+
+Both 3Dmol shells require Python 3. The browser shell uses only the Python
+standard library plus the system's default browser. The Qt shell additionally
+requires PyQt6, and its embedded 3D viewer requires PyQt6-WebEngine. CMake
+checks these imports with the Python interpreter found at configure time and
+prints a warning when the selected shell's dependencies are unavailable. At
+runtime, set `MULTIWFN_3DMOL_PYTHON` to use a Python interpreter other than
+`python3` from `PATH`.
+
+A browser-default build uses `MULTIWFN_3DMOL_DEFAULT_SHELL=browser` and
+produces `Multiwfn_3DmolGUI` with the same staged configuration and resources.
+Formal release packages use a separately tested, self-contained runtime and
+must not rely on this development staging layout.
+
+The original DISLIN/Motif GUI remains outside the CMake build; use the upstream
+`Makefile` when that legacy backend is required.
 
 ## Optional Features
 


### PR DESCRIPTION
## Summary

- stage `settings.ini` plus the 3Dmol and Qt frontend runtime resources into CMake GUI build directories
- keep each managed staging directory as an exact mirror, so deleted or renamed source resources cannot remain in incremental builds
- document the development-only runtime layout and check the selected shell's Python dependencies at configure time
- ignore the documented local build directory

This PR changes development build behavior only. It does not modify Multiwfn computational modules or numerical output, and it deliberately leaves the existing install rules unchanged.

## Public build interface

- Adds the `multiwfn_3dmol_resources` `ALL` target when `MULTIWFN_GUI_BACKEND=3dmol`.
- A Qt build produces `Multiwfn_QtGUI`; a browser-default build produces `Multiwfn_3DmolGUI`.
- Both build trees receive `settings.ini`, `resources/tools`, and `resources/frontend` so the executable can run directly from the build directory when development dependencies are installed.
- CMake warns when Python 3 is unavailable, or when a Qt-default build cannot import PyQt6 and PyQt6-WebEngine with its detected interpreter. The browser shell does not require those Qt packages.
- GUI installation layout is deliberately left unchanged for the relocatable-install design discussion in #15.

## Validation

- `git diff --check`
- `node --check frontend/3dmol-viewer/app.js`
- parsed the Python launchers and Qt entry point with `ast.parse`
- clean macOS Qt configure and build with `--parallel 8`
- clean macOS browser-shell configure and build with `--parallel 8`
- configured the Qt shell with `/usr/bin/python3` (without PyQt6) and confirmed the expected non-fatal dependency warning
- configured the browser shell with that same Python and confirmed there is no Qt dependency warning
- added a temporary frontend resource, built it into staging, deleted the source, rebuilt the same tree, and confirmed the staged copy was removed
- added a temporary `__pycache__` fixture and confirmed generated bytecode directories were absent from staging
- verified both build trees contain `settings.ini`, their executable, Python launchers, 3Dmol frontend, and Qt frontend

## Follow-up

The visual and numeric-control modernization is intentionally kept in a separate change and discussed in #13. A relocatable GUI install layout, including clean-package native file-selection acceptance, is tracked separately in #15.
