### PR TITLE
Modernize Qt GUI layout and numeric controls

### DIFF
--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -343,6 +343,72 @@ function optionalNumber(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function parseEditableNumber(value) {
+  const text = String(value ?? '').trim().replace(',', '.');
+  if (!text || /^[+-]$/.test(text) || text.endsWith('.') || /[eE][+-]?$/.test(text)) return null;
+  const parsed = Number(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function bindRangeNumberControl(range, field, options = {}) {
+  if (!range || !field) return;
+  const min = toNumber(range.min, Number.NEGATIVE_INFINITY);
+  const max = toNumber(range.max, Number.POSITIVE_INFINITY);
+  const decimals = Math.max(0, Number(options.decimals) || 0);
+  const format = (value) => Number(value).toFixed(decimals);
+  const normalize = (value) => clamp(value, min, max);
+  const notifyInput = (value, source) => {
+    options.onInput?.(value, { source });
+    return normalize(toNumber(range.value, value));
+  };
+
+  const commitField = () => {
+    const parsed = parseEditableNumber(field.value);
+    const next = normalize(parsed === null ? toNumber(range.value, min) : parsed);
+    range.value = String(next);
+    const applied = notifyInput(next, 'commit');
+    field.value = format(applied);
+    field.setAttribute('aria-invalid', 'false');
+    options.onCommit?.(applied);
+    return applied;
+  };
+
+  range.addEventListener('input', () => {
+    const next = normalize(toNumber(range.value, min));
+    const applied = notifyInput(next, 'range');
+    field.value = format(applied);
+    field.setAttribute('aria-invalid', 'false');
+  });
+  range.addEventListener('change', () => {
+    options.onCommit?.(normalize(toNumber(range.value, min)));
+  });
+
+  field.addEventListener('input', () => {
+    const parsed = parseEditableNumber(field.value);
+    if (parsed === null) {
+      field.removeAttribute('aria-invalid');
+      return;
+    }
+    const next = normalize(parsed);
+    range.value = String(next);
+    field.setAttribute('aria-invalid', String(next !== parsed));
+    notifyInput(next, 'field');
+  });
+
+  field.addEventListener('change', commitField);
+  field.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitField();
+      field.select();
+    } else if (event.key === 'Escape') {
+      field.value = format(normalize(toNumber(range.value, min)));
+      field.setAttribute('aria-invalid', 'false');
+      field.select();
+    }
+  });
+}
+
 function detectFormat(fileName, fallback = 'xyz') {
   const ext = String(fileName || '').split('.').pop().toLowerCase();
   if (ext === 'mol') return 'sdf';
@@ -2155,8 +2221,9 @@ function refreshOrbitalControls() {
 }
 
 function currentOrbitalIsovalue() {
-  const value = Math.abs(toNumber(
-    els.guiOrbitalIsovalueNumber?.value || els.guiOrbitalIsovalue?.value,
+  const edited = parseEditableNumber(els.guiOrbitalIsovalueNumber?.value);
+  const value = Math.abs(edited ?? toNumber(
+    els.guiOrbitalIsovalue?.value,
     state.gui.orbitalIsovalue
   ));
   return clamp(value, 0, 0.3);
@@ -2165,16 +2232,19 @@ function currentOrbitalIsovalue() {
 function syncOrbitalIsovalueControls(value, options = {}) {
   const next = clamp(Math.abs(toNumber(value, state.gui.orbitalIsovalue)), 0, 0.3);
   state.gui.orbitalIsovalue = next;
-  const text = next.toFixed(3).replace(/0+$/, '').replace(/\.$/, '') || '0';
-  if (els.guiOrbitalIsovalue && els.guiOrbitalIsovalue.value !== text) {
-    els.guiOrbitalIsovalue.value = text;
+  const rangeText = String(next);
+  const numberText = next.toFixed(4);
+  if (els.guiOrbitalIsovalue && els.guiOrbitalIsovalue.value !== rangeText) {
+    els.guiOrbitalIsovalue.value = rangeText;
   }
-  if (els.guiOrbitalIsovalueNumber && els.guiOrbitalIsovalueNumber.value !== text) {
-    els.guiOrbitalIsovalueNumber.value = text;
+  const preserveNumberInput = options.preserveNumberInput
+    || document.activeElement === els.guiOrbitalIsovalueNumber;
+  if (!preserveNumberInput && els.guiOrbitalIsovalueNumber?.value !== numberText) {
+    els.guiOrbitalIsovalueNumber.value = numberText;
   }
   if (options.layer) {
     options.layer.isovalue = next;
-    if (els.guiIsosurfaceValue) els.guiIsosurfaceValue.value = text;
+    if (els.guiIsosurfaceValue) els.guiIsosurfaceValue.value = rangeText;
   }
 }
 
@@ -3482,6 +3552,18 @@ function syncMultiwfnGuiControls() {
   els.guiAtomSize.value = atomRatio.toFixed(2);
   els.guiBondRadius.value = clamp(toNumber(els.bondRadius.value, 0.14) / 0.7, 0, 1).toFixed(2);
   els.guiLabelSize.value = String(state.gui.labelSize);
+  if (document.activeElement !== els.guiBondThresholdNumber) {
+    els.guiBondThresholdNumber.value = toNumber(els.guiBondThreshold.value, 1.15).toFixed(2);
+  }
+  if (document.activeElement !== els.guiAtomSizeNumber) {
+    els.guiAtomSizeNumber.value = atomRatio.toFixed(2);
+  }
+  if (document.activeElement !== els.guiBondRadiusNumber) {
+    els.guiBondRadiusNumber.value = toNumber(els.guiBondRadius.value, 0.2).toFixed(2);
+  }
+  if (document.activeElement !== els.guiLabelSizeNumber) {
+    els.guiLabelSizeNumber.value = String(state.gui.labelSize);
+  }
 
   const layer = activeGuiLayer();
   const selectedId = layer ? String(layer.id) : '';
@@ -3771,19 +3853,31 @@ function bindEvents() {
       renderScene(false);
     }
   });
-  els.guiAtomSize.addEventListener('input', () => {
-    els.atomScale.value = String(clamp(toNumber(els.guiAtomSize.value, 1) * 0.24, 0.12, 0.75));
-    updateStructureAppearance();
+  bindRangeNumberControl(els.guiBondThreshold, els.guiBondThresholdNumber, {
+    decimals: 2,
+    onInput: () => setStatus('Bonding threshold is stored for Multiwfn GUI parity')
   });
-  els.guiBondRadius.addEventListener('input', () => {
-    els.bondRadius.value = String(clamp(toNumber(els.guiBondRadius.value, 0.2) * 0.7, 0.04, 0.32));
-    updateStructureAppearance();
+  bindRangeNumberControl(els.guiAtomSize, els.guiAtomSizeNumber, {
+    decimals: 2,
+    onInput: (value) => {
+      els.atomScale.value = String(clamp(value * 0.24, 0.12, 0.75));
+      updateStructureAppearance();
+    }
   });
-  els.guiLabelSize.addEventListener('input', () => {
-    state.gui.labelSize = clamp(parseInt(els.guiLabelSize.value, 10) || 38, 0, 100);
-    scheduleAtomLabelStyleUpdate();
+  bindRangeNumberControl(els.guiBondRadius, els.guiBondRadiusNumber, {
+    decimals: 2,
+    onInput: (value) => {
+      els.bondRadius.value = String(clamp(value * 0.7, 0.04, 0.32));
+      updateStructureAppearance();
+    }
   });
-  els.guiBondThreshold.addEventListener('input', () => setStatus('Bonding threshold is stored for Multiwfn GUI parity'));
+  bindRangeNumberControl(els.guiLabelSize, els.guiLabelSizeNumber, {
+    decimals: 0,
+    onInput: (value) => {
+      state.gui.labelSize = clamp(Math.round(value), 0, 100);
+      scheduleAtomLabelStyleUpdate();
+    }
+  });
 
   els.guiOrbitalSelect.addEventListener('change', () => setActiveGuiLayer(els.guiOrbitalSelect.value, { orbitalSelection: true }));
   els.guiOrbitalInput.addEventListener('change', () => {
@@ -3797,12 +3891,12 @@ function bindEvents() {
   els.guiOrbPrev.addEventListener('click', () => selectGuiOrbitalOffset(-1));
   els.guiOrbNext.addEventListener('click', () => selectGuiOrbitalOffset(1));
   els.guiOrbInfo.addEventListener('click', () => activateTab('layers'));
-  const updateOrbitalIsovalue = (event) => {
+  const updateOrbitalIsovalue = (value, event = {}) => {
     const layer = activeGuiLayer();
-    const value = event?.target === els.guiOrbitalIsovalueNumber
-      ? els.guiOrbitalIsovalueNumber.value
-      : els.guiOrbitalIsovalue.value;
-    syncOrbitalIsovalueControls(value, layer ? { layer } : {});
+    syncOrbitalIsovalueControls(value, {
+      ...(layer ? { layer } : {}),
+      preserveNumberInput: event.source === 'field'
+    });
     if (layer) {
       renderLayerList();
       renderScene(false);
@@ -3812,10 +3906,11 @@ function bindEvents() {
     const index = Number(activeGuiLayer()?.orbitalIndex || els.guiOrbitalInput.value || 0);
     if (index > 0) requestGuiOrbital(index, { forceRecompute: true });
   };
-  els.guiOrbitalIsovalue.addEventListener('input', updateOrbitalIsovalue);
-  els.guiOrbitalIsovalueNumber.addEventListener('input', updateOrbitalIsovalue);
-  els.guiOrbitalIsovalue.addEventListener('change', reloadOrbitalAtIsovalue);
-  els.guiOrbitalIsovalueNumber.addEventListener('change', reloadOrbitalAtIsovalue);
+  bindRangeNumberControl(els.guiOrbitalIsovalue, els.guiOrbitalIsovalueNumber, {
+    decimals: 4,
+    onInput: updateOrbitalIsovalue,
+    onCommit: reloadOrbitalAtIsovalue
+  });
 
   els.guiIsosurfaceLayer.addEventListener('change', () => setActiveGuiLayer(els.guiIsosurfaceLayer.value));
   [
@@ -4043,9 +4138,13 @@ function cacheElements() {
     guiShowAxis: byId('gui-show-axis'),
     guiShowSecond: byId('gui-show-second'),
     guiBondThreshold: byId('gui-bond-threshold'),
+    guiBondThresholdNumber: byId('gui-bond-threshold-number'),
     guiAtomSize: byId('gui-atom-size'),
+    guiAtomSizeNumber: byId('gui-atom-size-number'),
     guiBondRadius: byId('gui-bond-radius'),
+    guiBondRadiusNumber: byId('gui-bond-radius-number'),
     guiLabelSize: byId('gui-label-size'),
+    guiLabelSizeNumber: byId('gui-label-size-number'),
     guiOrbitalSelect: byId('gui-orbital-select'),
     guiOrbitalList: byId('gui-orbital-list'),
     guiOrbitalStatus: byId('gui-orbital-status'),

--- a/frontend/3dmol-viewer/index.html
+++ b/frontend/3dmol-viewer/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Multiwfn 3Dmol GUI</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="modern.css">
     <script defer src="vendor/3Dmol-min.js"></script>
     <script defer src="app.js"></script>
   </head>
@@ -28,13 +29,13 @@
           </div>
 
           <div class="gui-window-bar">
-            <button id="gui-return" class="primary-action" type="button">RETURN</button>
+            <button id="gui-return" class="primary-action" type="button">Return</button>
             <button id="gui-rot-up" type="button">Up</button>
             <button id="gui-rot-down" type="button">Down</button>
             <button id="gui-rot-left" type="button">Left</button>
             <button id="gui-rot-right" type="button">Right</button>
-            <button id="gui-reset" type="button">Reset view</button>
-            <button id="gui-save-picture" type="button">Save picture</button>
+            <button id="gui-reset" type="button">Reset</button>
+            <button id="gui-save-picture" type="button">Save</button>
           </div>
 
           <div class="gui-pad" aria-label="View rotation">
@@ -42,29 +43,42 @@
 
           <section class="gui-section is-active" data-gui-section="molecule">
             <div class="group">
-              <h2>Geometry structure / orbital isosurfaces</h2>
+              <h2>Scene</h2>
               <div class="checks">
                 <label><input id="gui-show-structure" type="checkbox" checked> Show molecule</label>
                 <label><input id="gui-show-labels" type="checkbox"> Show labels</label>
                 <label><input id="gui-show-axis" type="checkbox" checked> Show axis</label>
-                <label><input id="gui-show-second" type="checkbox"> Show+Sel. isosur#2</label>
+                <label><input id="gui-show-second" type="checkbox"> Show surface 2</label>
               </div>
+              <h3 class="subsection-title">Geometry</h3>
               <div class="control-grid">
-                <label>
-                  <span>Bonding threshold</span>
-                  <input id="gui-bond-threshold" type="range" min="0" max="5" step="0.01" value="1.15">
+                <label class="parameter-control">
+                  <span class="parameter-heading"><span>Bonding threshold</span><small>relative</small></span>
+                  <span class="inline-number-control">
+                    <input id="gui-bond-threshold" type="range" min="0" max="5" step="0.01" value="1.15">
+                    <input id="gui-bond-threshold-number" type="text" inputmode="decimal" value="1.15" aria-label="Bonding threshold value">
+                  </span>
                 </label>
-                <label>
-                  <span>Ratio of atomic size</span>
-                  <input id="gui-atom-size" type="range" min="0" max="5" step="0.01" value="1">
+                <label class="parameter-control">
+                  <span class="parameter-heading"><span>Atom size ratio</span><small>scale</small></span>
+                  <span class="inline-number-control">
+                    <input id="gui-atom-size" type="range" min="0" max="5" step="0.01" value="1">
+                    <input id="gui-atom-size-number" type="text" inputmode="decimal" value="1.00" aria-label="Atom size ratio value">
+                  </span>
                 </label>
-                <label>
-                  <span>Radius of bonds</span>
-                  <input id="gui-bond-radius" type="range" min="0" max="1" step="0.01" value="0.2">
+                <label class="parameter-control">
+                  <span class="parameter-heading"><span>Bond radius</span><small>relative</small></span>
+                  <span class="inline-number-control">
+                    <input id="gui-bond-radius" type="range" min="0" max="1" step="0.01" value="0.2">
+                    <input id="gui-bond-radius-number" type="text" inputmode="decimal" value="0.20" aria-label="Bond radius value">
+                  </span>
                 </label>
-                <label>
-                  <span>Size of atomic labels</span>
-                  <input id="gui-label-size" type="range" min="0" max="100" step="1" value="38">
+                <label class="parameter-control">
+                  <span class="parameter-heading"><span>Label size</span><small>px</small></span>
+                  <span class="inline-number-control">
+                    <input id="gui-label-size" type="range" min="0" max="100" step="1" value="38">
+                    <input id="gui-label-size-number" type="text" inputmode="numeric" value="38" aria-label="Label size value">
+                  </span>
                 </label>
               </div>
             </div>
@@ -79,11 +93,22 @@
                   <span>Orbital index</span>
                   <input id="gui-orbital-input" type="text" value="0">
                 </label>
-                <label>
+                <label class="isovalue-control">
                   <span>Isovalue</span>
                   <span class="inline-number-control">
                     <input id="gui-orbital-isovalue" type="range" min="0" max="0.3" step="0.001" value="0.015">
-                    <input id="gui-orbital-isovalue-number" type="number" min="0" max="0.3" step="0.001" value="0.015">
+                    <input
+                      id="gui-orbital-isovalue-number"
+                      type="text"
+                      inputmode="decimal"
+                      value="0.0150"
+                      data-min="0"
+                      data-max="0.3"
+                      data-step="0.001"
+                      aria-label="Orbital isovalue"
+                      autocomplete="off"
+                      spellcheck="false"
+                    >
                   </span>
                 </label>
               </div>
@@ -268,7 +293,7 @@
           </section>
 
           <div class="gui-menu-strip" aria-label="Original GUI menus">
-            <button id="gui-menu-orbital-info" type="button">Orbital info.</button>
+            <button id="gui-menu-orbital-info" type="button">Orbital info</button>
             <div id="gui-isosur1-menu-control" class="gui-menu-control">
               <button
                 id="gui-menu-isosur1"
@@ -276,7 +301,7 @@
                 aria-haspopup="menu"
                 aria-expanded="false"
                 aria-controls="gui-isosur1-menu"
-              >Isosur#1 style</button>
+              >Surface 1</button>
               <div
                 id="gui-isosur1-menu"
                 class="gui-style-menu"
@@ -350,18 +375,18 @@
                 </button>
               </div>
             </div>
-            <button id="gui-menu-isosur2" type="button">Isosur#2 style</button>
+            <button id="gui-menu-isosur2" type="button">Surface 2</button>
             <select id="gui-menu-quality" aria-label="Isosurface quality">
               <option value="25000">Very poor quality (25k)</option>
               <option value="50000">Poor quality (50k)</option>
-              <option value="120000" selected>Isosur. quality: Default (120k)</option>
+              <option value="120000" selected>Quality: Default (120k)</option>
               <option value="300000">Good quality (300k)</option>
               <option value="500000">High quality (500k)</option>
               <option value="1000000">Very high quality (1000k)</option>
               <option value="1500000">Perfect quality (1500k)</option>
             </select>
-            <button id="gui-menu-view" type="button">Set view</button>
-            <button id="gui-menu-settings" type="button">Other settings</button>
+            <button id="gui-menu-view" type="button">View</button>
+            <button id="gui-menu-settings" type="button">Settings</button>
             <button id="gui-menu-tools" type="button">Tools</button>
           </div>
         </section>

--- a/frontend/3dmol-viewer/modern.css
+++ b/frontend/3dmol-viewer/modern.css
@@ -1,0 +1,780 @@
+/* Cross-platform desktop shell layered over the legacy-compatible controls. */
+:root {
+  --bg: #eef1f5;
+  --panel: #f7f8fa;
+  --panel-soft: #edf1f5;
+  --text: #1c2430;
+  --muted: #667085;
+  --line: #d7dde5;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --accent-soft: #eaf2ff;
+  --danger: #c43d55;
+  --control: #ffffff;
+  --shadow: 0 8px 28px rgba(23, 31, 44, 0.10);
+  --focus: 0 0 0 3px rgba(37, 99, 235, 0.20);
+}
+
+body {
+  color: var(--text);
+  background: var(--bg);
+  font: 14px/1.35 var(--ui-font);
+}
+
+.app-shell {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 22vw, 320px);
+  grid-template-rows: minmax(0, 1fr);
+  gap: 0;
+  width: 100%;
+  height: 100vh;
+  min-height: 520px;
+  padding-top: 50px;
+  background: var(--bg);
+}
+
+.viewport-wrap {
+  order: 1;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  overflow: hidden;
+  background: #ffffff;
+  border: 0;
+  border-right: 1px solid var(--line);
+  box-shadow: none;
+}
+
+#viewer {
+  inset: 0;
+  background: #ffffff;
+}
+
+.sidebar {
+  order: 2;
+  width: auto;
+  min-width: 0;
+  min-height: 0;
+  max-height: none;
+  padding: 0 12px 14px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  color: var(--text);
+  background: var(--panel);
+  border: 0;
+  box-shadow: none;
+  scrollbar-color: #b7c0cc transparent;
+  scrollbar-width: thin;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 14px 2px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand h1 {
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.1;
+}
+
+.brand p {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+#status {
+  max-width: 140px;
+  flex: 0 1 auto;
+  padding: 4px 7px;
+  overflow: hidden;
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gui-modebar,
+.gui-pad,
+.advanced-panels,
+.gui-section:not([data-gui-section="molecule"]) {
+  display: none;
+}
+
+.multiwfn-gui {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding-top: 0;
+}
+
+.gui-menu-strip {
+  position: fixed;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 50px;
+  padding: 7px 12px;
+  overflow: visible;
+  background: rgba(251, 252, 253, 0.97);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  box-shadow: 0 2px 12px rgba(23, 31, 44, 0.07);
+  backdrop-filter: blur(12px);
+}
+
+.gui-menu-strip button,
+.gui-menu-strip select {
+  width: auto;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: 500 13px/1 var(--ui-font);
+  text-align: left;
+}
+
+.gui-menu-strip select {
+  max-width: 230px;
+  appearance: auto;
+}
+
+.gui-menu-strip button:hover,
+.gui-menu-strip select:hover {
+  color: var(--text);
+  background: var(--panel-soft);
+  border-color: var(--line);
+}
+
+.gui-menu-control {
+  position: relative;
+  flex: 0 0 auto;
+  height: 34px;
+}
+
+.gui-style-menu,
+.gui-style-submenu {
+  z-index: 12;
+  box-sizing: border-box;
+  max-width: calc(100vw - 24px);
+  color: var(--text);
+  background: var(--control);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.gui-style-menu {
+  position: absolute;
+  top: 38px;
+  left: 0;
+  width: 176px;
+  padding: 5px;
+}
+
+.gui-style-submenu {
+  position: fixed;
+  z-index: 13;
+  width: 236px;
+  padding: 10px;
+}
+
+.gui-style-menu .gui-style-menu-item,
+.gui-background-menu button {
+  min-height: 32px;
+  padding: 0 8px;
+  color: var(--text);
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+}
+
+.gui-style-menu .gui-style-menu-item:hover,
+.gui-style-menu .gui-style-menu-item[aria-expanded="true"],
+.gui-background-menu button:hover,
+.gui-background-menu button[aria-checked="true"] {
+  background: var(--accent-soft);
+}
+
+.gui-menu-check {
+  border-color: #9ba6b4;
+  border-radius: 3px;
+}
+
+.gui-window-bar {
+  display: grid;
+  grid-template-areas:
+    "return return reset save"
+    "left up down right";
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin: 12px 0;
+}
+
+#gui-return { grid-area: return; }
+#gui-reset { grid-area: reset; }
+#gui-save-picture { grid-area: save; }
+#gui-rot-left { grid-area: left; }
+#gui-rot-up { grid-area: up; }
+#gui-rot-down { grid-area: down; }
+#gui-rot-right { grid-area: right; }
+
+button,
+.gui-window-bar button,
+.gui-pad button,
+.gui-menu-strip button {
+  border-radius: 6px;
+}
+
+.gui-window-bar button {
+  width: 100%;
+  height: 32px;
+  min-width: 0;
+  padding: 0 6px;
+  color: var(--text);
+  background: var(--control);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: none;
+  font: 500 12px/1 var(--ui-font);
+}
+
+.gui-window-bar button:hover {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-color: #a9c4f7;
+}
+
+.gui-window-bar .primary-action {
+  color: #ffffff;
+  background: #202733;
+  border-color: #202733;
+}
+
+.gui-window-bar .primary-action:hover {
+  color: #ffffff;
+  background: #111827;
+  border-color: #111827;
+}
+
+.gui-section.is-active {
+  display: block;
+}
+
+.group {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding: 13px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.gui-section .group:first-child {
+  border-top: 0;
+}
+
+h2 {
+  margin: 0 0 2px;
+  color: var(--text);
+  font: 650 15px/1.2 var(--ui-font);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.subsection-title {
+  margin: 3px 0 0;
+  padding-top: 12px;
+  color: var(--text);
+  border-top: 1px solid var(--line);
+  font: 650 15px/1.2 var(--ui-font);
+}
+
+.checks {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px 8px;
+}
+
+.checks label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 26px;
+  margin: 0;
+  color: var(--text);
+  font: 500 13px/1.15 var(--ui-font);
+  white-space: nowrap;
+}
+
+input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
+}
+
+.control-grid,
+.control-grid.triple {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+label {
+  display: block;
+  margin: 0;
+  color: var(--text);
+  font: 500 13px/1.25 var(--ui-font);
+}
+
+label > span {
+  text-align: left;
+}
+
+.parameter-control {
+  display: grid;
+  gap: 5px;
+}
+
+.parameter-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.parameter-heading small {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+input[type="range"] {
+  width: 100%;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+select,
+input[type="number"],
+input[type="text"] {
+  min-height: 32px;
+  padding: 0 8px;
+  color: var(--text);
+  background: var(--control);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: 13px/1.1 var(--mono-font);
+}
+
+.inline-number-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 76px;
+  gap: 8px;
+  align-items: center;
+}
+
+.inline-number-control input[type="text"],
+.inline-number-control input[type="number"] {
+  width: 100%;
+  min-width: 0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.orbital-list {
+  display: block;
+  width: 100%;
+  height: clamp(132px, 21vh, 210px);
+  min-height: 132px;
+  max-height: 210px;
+  overflow: auto;
+  color: var(--text);
+  background: var(--control);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: 500 13px/1.2 var(--mono-font);
+}
+
+.orbital-row {
+  display: block;
+  width: 100%;
+  height: 24px;
+  min-width: 0;
+  padding: 0 7px;
+  overflow: hidden;
+  color: var(--text);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  font: inherit;
+  line-height: 24px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orbital-row:hover {
+  color: var(--text);
+  background: var(--panel-soft);
+}
+
+.orbital-row[aria-selected="true"] {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+.orbital-status {
+  min-height: 18px;
+  margin: 0;
+  overflow: hidden;
+  color: #14753f;
+  font: 500 12px/1.25 var(--ui-font);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orbital-status[data-state="error"] {
+  color: var(--danger);
+}
+
+.orbital-panel .control-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  align-items: stretch;
+}
+
+#gui-orbital-input {
+  width: 100%;
+}
+
+.isovalue-control {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  background: var(--accent-soft);
+  border: 1px solid #c8dafb;
+  border-radius: 8px;
+}
+
+.isovalue-control > span:first-child {
+  font-weight: 650;
+}
+
+#gui-orbital-isovalue {
+  width: 100%;
+  height: 18px;
+}
+
+#gui-orbital-isovalue-number {
+  min-height: 32px;
+  padding: 0 7px;
+  font: 13px/1.1 var(--mono-font);
+}
+
+.button-row {
+  display: none;
+}
+
+.orbital-panel .button-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  width: 100%;
+  margin: 0;
+}
+
+.orbital-panel .button-row button {
+  min-width: 0;
+  height: 32px;
+  padding: 0 5px;
+  color: var(--text);
+  background: var(--control);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: none;
+  font: 500 12px/1 var(--ui-font);
+}
+
+.orbital-panel .button-row button:hover {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-color: #a9c4f7;
+}
+
+.hud {
+  left: 16px;
+  right: 16px;
+  bottom: 14px;
+}
+
+.hud span {
+  padding: 6px 9px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(23, 31, 44, 0.08);
+  backdrop-filter: blur(8px);
+  font: 12px/1.2 var(--ui-font);
+}
+
+.orientation-widget {
+  right: 16px;
+  bottom: 50px;
+  background: transparent;
+}
+
+.plot-panel {
+  border-color: var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+@media (min-width: 761px) and (max-height: 960px) {
+  .brand {
+    padding: 7px 2px 6px;
+  }
+
+  .brand h1 {
+    font-size: 16px;
+  }
+
+  .brand p {
+    margin-top: 1px;
+    font-size: 11px;
+  }
+
+  #status {
+    max-width: 130px;
+    padding: 3px 6px;
+    font-size: 10px;
+  }
+
+  .gui-window-bar {
+    gap: 4px;
+    margin: 6px 0;
+  }
+
+  .gui-window-bar button {
+    height: 27px;
+    padding: 0 4px;
+    font-size: 11px;
+  }
+
+  .group {
+    gap: 5px;
+    padding: 7px 0;
+  }
+
+  h2,
+  .subsection-title {
+    font-size: 14px;
+  }
+
+  .subsection-title {
+    margin-top: 1px;
+    padding-top: 7px;
+  }
+
+  .checks {
+    gap: 2px 6px;
+  }
+
+  .checks label {
+    min-height: 20px;
+    font-size: 12px;
+  }
+
+  .control-grid,
+  .control-grid.triple {
+    gap: 5px;
+  }
+
+  .parameter-control {
+    grid-template-columns: minmax(96px, 0.82fr) minmax(0, 1.18fr);
+    align-items: center;
+    gap: 6px;
+  }
+
+  .parameter-heading {
+    display: grid;
+    gap: 0;
+  }
+
+  .parameter-heading small {
+    font-size: 10px;
+  }
+
+  .inline-number-control {
+    grid-template-columns: minmax(0, 1fr) 58px;
+    gap: 5px;
+  }
+
+  select,
+  input[type="number"],
+  input[type="text"] {
+    min-height: 27px;
+    padding-inline: 5px;
+  }
+
+  .orbital-list {
+    height: clamp(64px, 10vh, 100px);
+    min-height: 64px;
+    max-height: 100px;
+  }
+
+  .orbital-row {
+    height: 20px;
+    line-height: 20px;
+  }
+
+  .orbital-status {
+    min-height: 14px;
+    font-size: 11px;
+  }
+
+  .orbital-panel .control-grid {
+    gap: 5px;
+  }
+
+  .orbital-panel .control-grid > label:not(.isovalue-control) {
+    display: grid;
+    grid-template-columns: 74px minmax(0, 1fr);
+    align-items: center;
+    gap: 6px;
+  }
+
+  .isovalue-control {
+    grid-template-columns: 66px minmax(0, 1fr);
+    align-items: center;
+    gap: 6px;
+    padding: 6px;
+  }
+
+  #gui-orbital-isovalue-number {
+    min-height: 27px;
+    padding-inline: 5px;
+  }
+
+  .orbital-panel .button-row {
+    gap: 4px;
+  }
+
+  .orbital-panel .button-row button {
+    height: 27px;
+    font-size: 11px;
+  }
+}
+
+@media (min-width: 761px) and (max-height: 680px) {
+  .brand {
+    padding-block: 5px;
+  }
+
+  .brand p {
+    display: none;
+  }
+
+  .gui-window-bar {
+    margin-block: 4px;
+  }
+
+  .group {
+    padding-block: 5px;
+  }
+
+  .isovalue-control {
+    padding-block: 5px;
+  }
+
+  .orbital-list {
+    height: 56px;
+    min-height: 56px;
+  }
+}
+
+@media (min-width: 761px) and (max-height: 630px) {
+  .gui-window-bar button,
+  .orbital-panel .button-row button {
+    height: 25px;
+  }
+
+  .group {
+    padding-block: 3px;
+  }
+
+  .orbital-list {
+    height: 40px;
+    min-height: 40px;
+  }
+}
+
+@media (max-width: 760px) {
+  .gui-menu-strip {
+    position: absolute;
+    height: auto;
+    min-height: 50px;
+    flex-wrap: wrap;
+  }
+
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(390px, 58vh) auto;
+    width: 100%;
+    height: auto;
+    min-height: 100vh;
+    padding-top: 86px;
+  }
+
+  .viewport-wrap {
+    min-height: 390px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .sidebar {
+    width: auto;
+    min-width: 0;
+    max-height: none;
+    overflow: visible;
+  }
+}
+
+@media (max-width: 420px) {
+  .app-shell {
+    padding-top: 122px;
+  }
+
+  .checks {
+    grid-template-columns: 1fr;
+  }
+
+  .gui-window-bar {
+    grid-template-areas:
+      "return return"
+      "reset save"
+      "left right"
+      "up down";
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
+++ b/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
@@ -84,6 +84,19 @@ def is_wsl() -> bool:
         return False
 
 
+def recommended_window_geometry(screen_width: int, screen_height: int) -> tuple[int, int, int, int]:
+    """Return minimum and initial window sizes that stay within the usable screen."""
+    width = max(1, int(screen_width))
+    height = max(1, int(screen_height))
+    minimum_width = min(width, 800)
+    minimum_height = min(height, 560)
+    initial_width = min(width, 1440, max(1200, round(width * 0.92)))
+    initial_height = min(height, 960, max(800, round(height * 0.90)))
+    initial_width = max(minimum_width, initial_width)
+    initial_height = max(minimum_height, initial_height)
+    return minimum_width, minimum_height, initial_width, initial_height
+
+
 def open_system_browser(url: str) -> bool:
     if is_wsl():
         cmd_exe = Path("/mnt/c/Windows/System32/cmd.exe")
@@ -439,7 +452,7 @@ class MultiwfnQtGui(QMainWindow):
             pass
 
         self.setWindowTitle("Multiwfn Qt GUI")
-        self.resize(1280, 820)
+        self._configure_window_size()
         self._build_menu()
         self._build_ui()
         self._load_manifest()
@@ -448,6 +461,20 @@ class MultiwfnQtGui(QMainWindow):
         self._start_startup_profiler()
         if open_browser:
             QTimer.singleShot(0, self._open_in_browser)
+
+    def _configure_window_size(self) -> None:
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            self.setMinimumSize(900, 600)
+            self.resize(1360, 900)
+            return
+        available = screen.availableGeometry()
+        minimum_width, minimum_height, initial_width, initial_height = recommended_window_geometry(
+            available.width(),
+            available.height(),
+        )
+        self.setMinimumSize(minimum_width, minimum_height)
+        self.resize(initial_width, initial_height)
 
     def _mark_startup(self, name: str) -> None:
         if self.profile_startup:


### PR DESCRIPTION
## Summary

- replace the experimental Qt/3Dmol shell's narrow legacy-inspired layout with a clearer viewer-and-sidebar desktop layout
- add responsive styling for short screens and the `760px` / `420px` browser breakpoints
- add editable numeric fields beside geometry, label, and orbital-isovalue sliders
- make the initial Qt window size monotonic with available screen size and cap it at `1440×960`

This PR changes frontend and Qt launcher UX only. It does not modify Multiwfn computational modules or numerical output.

## Design discussion

Closes #13.

| Current `main` | Proposed layout |
| --- | --- |
| ![Current GUI](https://raw.githubusercontent.com/KaguraSayuki/Multiwfn/gui-modernization-assets/docs/gui-modernization/before.png) | ![Modernized GUI](https://raw.githubusercontent.com/KaguraSayuki/Multiwfn/gui-modernization-assets/docs/gui-modernization/after.png) |

Both screenshots use the same manifest, structure, and `1440×900` browser viewport. The design issue records the responsive and interaction acceptance criteria used for this change.

## Interaction behavior

- Slider and text inputs stay synchronized and committed values are clamped to each control's supported range.
- Numeric fields accept decimal commas and temporary partial input; Enter commits, Escape restores the current slider value, and blur/change commits.
- Orbital isovalue changes preview against the active layer while dragging or typing, but orbital recomputation occurs only on commit.
- Atom-size and bond-radius controls retain the incremental `updateStructureAppearance()` path.
- Label-size changes retain the frame-batched `scheduleAtomLabelStyleUpdate()` path.
- The Qt window uses available screen geometry, never shrinks when screen dimensions grow, and remains bounded by both the screen and `1440×960`.

## Validation after rebasing onto current `main`

- `git diff --check upstream/main...HEAD`
- `node --check frontend/3dmol-viewer/app.js`
- parsed `qt_multiwfn_gui.py` with Python `ast.parse`
- exhaustively checked window-width monotonicity from 1 through 2000 pixels at representative screen heights
- checked `1200×800 → 1201×801` does not shrink and `1920×1080` caps at `1440×960`
- clean macOS Qt CMake Release configure and build with `--parallel 8`
- clean macOS browser-shell CMake Release configure and build with `--parallel 8`
- verified both staged runtime trees contain `modern.css` byte-identical to the source stylesheet

Interactive slider/input behavior, scene controls, orbital commit semantics, and responsive layouts were exercised while preparing #13. Cross-platform GUI packaging and Rocky Linux 8 compatibility are left to the required PR workflows.
