### PR TITLE
Derive release titles from version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,9 +322,10 @@ jobs:
           cp release-artifacts/Multiwfn_noGUI-package-macOS/Multiwfn_noGUI-macOS.tar.gz release-assets/
           cp release-artifacts/Multiwfn_noGUI-package-Windows/Multiwfn_noGUI-Windows.zip release-assets/
           sha256sum release-assets/* > release-assets/SHA256SUMS.txt
-          cat > RELEASE_NOTES.md <<'EOF'
-          Cross-platform noGUI build of Multiwfn 2026.6.2.
-
+          version="${GITHUB_REF_NAME#v}"
+          version="${version%-nogui.*}"
+          printf 'Cross-platform noGUI build of Multiwfn %s.\n\n' "$version" > RELEASE_NOTES.md
+          cat >> RELEASE_NOTES.md <<'EOF'
           This release keeps the upstream Fortran source behavior and adds a minimal CMake/GitHub Actions build path for noGUI binaries.
           The upstream Multiwfn license is included as LICENSE.txt in this release and inside each platform archive.
 
@@ -360,6 +361,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          version="${GITHUB_REF_NAME#v}"
+          version="${version%-nogui.*}"
           gh release create "$GITHUB_REF_NAME" release-assets/* \
-            --title "Multiwfn 2026.6.2 noGUI cross-platform build" \
+            --title "Multiwfn ${version} noGUI cross-platform build" \
             --notes-file RELEASE_NOTES.md

--- a/.github/workflows/gui-demo-release.yml
+++ b/.github/workflows/gui-demo-release.yml
@@ -336,6 +336,8 @@ jobs:
             tag="gui-qt-preview-ci-${GITHUB_RUN_NUMBER}"
           fi
           if [[ "$tag" == v*-gui.* ]]; then
+            version="${tag#v}"
+            version="${version%-gui.*}"
             cat > release_notes.md <<'EOF'
           This release publishes Multiwfn executables with the Qt/3Dmol GUI backend.
 
@@ -348,7 +350,7 @@ jobs:
 
           Note: the Qt/3Dmol GUI is still under active development. Please report GUI workflow regressions through issues.
           EOF
-            echo "RELEASE_TITLE=Multiwfn 2026.6.2 GUI build" >> "$GITHUB_ENV"
+            echo "RELEASE_TITLE=Multiwfn ${version} GUI build" >> "$GITHUB_ENV"
             echo "RELEASE_PRERELEASE=false" >> "$GITHUB_ENV"
             exit 0
           fi


### PR DESCRIPTION
## Summary

- derive GUI and noGUI release version names from their Git tags
- remove stale 2026.6.2 version text from generated release titles and noGUI notes

## Validation

- verified `v2026.7.10-gui.1` resolves to `2026.7.10`
- verified `v2026.7.10-nogui.1` resolves to `2026.7.10`
