### PR TITLE
Display explicit and inferred bond orders in the 3Dmol GUI

### DIFF
--- a/define.f90
+++ b/define.f90
@@ -350,9 +350,10 @@ real*8 spcred !Spacing of reduced grids
 real*8 orgx_neigh,orgy_neigh,orgz_neigh !Starting position of reduced grids
 
 !-------- Connectivity matrix
-!Loaded from .mol/mol2 using readmol/readmol2 or readmolconn (from mol), value is formal bond order; can also be guessed via genconnmat, value is 1/0 (connected, not connected)
+!Loaded from .fch/.mol/mol2 using their readers or readmolconn (from mol), value is formal bond order; can also be guessed via genconnmat, value is 1/0 (connected, not connected)
 !Special: ar (aromatic) in mol2 is load as 4, am (nitrogen in piptide bond) in mol2 is read as 1, "un = unknown", "nc = not connected" and "du = dummy" are read as 0
 integer*2,allocatable :: connmat(:,:) !Diagonal terms are always zero
+integer :: iconnsource=0 !=0: unavailable, =1: explicit input-file topology, =2: geometry-inferred topology
 
 !-------- Energy related arrays and matrices
 real*8,allocatable,target :: FmatA(:,:),FmatB(:,:) !Fock matrix of total/alpha and beta spin

--- a/docs/3dmol_bond_order_display.md
+++ b/docs/3dmol_bond_order_display.md
@@ -1,0 +1,133 @@
+# 3Dmol displayed bond-order perception
+
+This note describes the structural bond orders drawn by the 3Dmol frontend.
+They are deliberately separate from Mayer, GWBO, Wiberg, Mulliken, and FBO
+values calculated by Multiwfn. A displayed line is a visualization decision;
+it is not evidence that a chemical bond exists and it does not affect a
+wavefunction calculation.
+
+## Data precedence
+
+1. When a Gaussian formatted checkpoint contains all four optional
+   `MxBond`/`NBond`/`IBond`/`RBond` fields, Multiwfn validates and loads them
+   into `connmat`. The 3Dmol backend exports that explicit topology as MOL2;
+   `RBond=1.5` is carried as an aromatic bond. Missing, dimensionally
+   inconsistent, or unsupported values leave connectivity unavailable.
+2. SDF/MOL and MOL2 bond orders are preserved. CIF bond records are also left
+   to the 3Dmol parser.
+3. PDB/PQR `CONECT` records preserve the input topology. When all parsed orders
+   are single, only the orders on those edges are inferred.
+4. XYZ, cube-derived XYZ, FCHK files without the optional arrays, and other
+   structures without explicit topology use the
+   perception pipeline below.
+
+This prevents a geometry heuristic from overwriting bond orders already stored
+by the source program while still making geometry-only quantum-chemistry files
+useful. The FCHK arrays describe Gaussian's stored formal drawing topology;
+they remain distinct from wavefunction-derived Mayer, Wiberg, or FBO values.
+
+## Perception pipeline
+
+### 1. Connectivity: Multiwfn behavior
+
+An atom pair is a normal bond candidate when
+
+```text
+distance <= bondingThreshold * (CSD radius 1 + CSD radius 2)
+```
+
+The default `bondingThreshold` is 1.15. The radii are copied from Multiwfn's
+`covr` table in `define.f90` (Dalton Trans. 2008, 2832-2838). The frontend's
+Bonding threshold control now reruns this step instead of being a parity-only
+placeholder. This choice retains Multiwfn's better behavior for cases such as
+longer coordination bonds that GaussView can omit.
+
+### 2. Initial order: GaussView element-pair thresholds
+
+For a connected pair, the distance is divided by the sum of the GaussView
+covalent radii. The linked GaussView element-pair table reduces to these upper
+limits:
+
+| Ratio | Candidate |
+| --- | --- |
+| `<= 0.81` | triple |
+| `<= 0.90` | double |
+| `<= 0.94` | resonant/aromatic candidate |
+| otherwise | single |
+
+The measured table is preferred to the approximate 0.78/0.88/0.91 equilibrium
+figures in the reverse-engineering notes. For example, all C-C entries are
+reproduced by multiplying the 1.54 Angstrom GaussView radius sum by these
+ratios. The thresholds are applied directly, without a molecule-specific
+tolerance.
+
+### 3. Element and valence constraints
+
+Hydrogen and halogens cannot become multiple bonds; oxygen-family atoms are
+capped at double bonds; carbon/nitrogen-family atoms may reach triple bonds.
+Normal connectivity is selected first, then multiple bonds are upgraded in
+shortest normalized-distance order while respecting typical coordination and
+valence limits. Group 1/2 and transition metals retain high coordination caps,
+because coordination number must not be confused with oxidation state.
+
+### 4. Aromatic validation
+
+A resonant distance is only a candidate. The implementation enumerates 5- and
+6-membered cycles and requires:
+
+- planarity within 0.18 Angstrom;
+- conjugatable ring elements;
+- a p contribution or an eligible heteroatom lone-pair donation at every ring
+  position;
+- a `4n+2` pi-electron count.
+
+Only then are all ring edges assigned order 1.5. A rejected resonant candidate
+falls back to a single bond.
+
+### 5. Weak bonds
+
+Pairs outside the normal Multiwfn cutoff but within 1.5 times the GaussView
+radius sum are weak candidates. A weak edge is retained only if it joins two
+otherwise disconnected strong-bond components, and at most one weak edge is
+kept per atom. This implements the useful part of the reverse-engineered weak
+bond cleanup without filling ordinary molecules with dashed shortcuts.
+
+## 3Dmol representation
+
+The perception result is written symmetrically to each 3Dmol atom's `bonds`
+and `bondOrder` arrays. Orders are 0.5, 1, 1.5, 2, or 3. Stick styles therefore
+render weak/fractional bonds dashed and double/triple bonds with multiple
+cylinders. The frontend's wireframe option uses very thin sticks because the
+3Dmol line renderer does not reliably render fractional aromatic bonds.
+
+Right-clicking two selected adjacent atoms exposes both the displayed order
+and the independent Multiwfn bond-order analyses.
+
+## Validation
+
+Run the focused tests with:
+
+```sh
+node --test frontend/3dmol-viewer/tests/bond-perception.test.js
+```
+
+The cases cover C-C/C=C/C-triple-C, C=O, N-triple-N, hydrogen/halogen caps,
+Pt-N connectivity, benzene, a five-membered heteroaromatic ring, a puckered
+saturated ring, weak-bond cleanup, reciprocal 3Dmol arrays, explicit topology,
+and PDB-style topology-only order inference.
+
+## Scope and limitations
+
+The inference path is intentionally deterministic and geometry-first. Formal
+charges, unusual oxidation states, rings outside the supported 5/6-membered
+set, and multicenter or metal-metal bonding can require an explicit SDF/MOL2
+topology or manual interpretation. Quantitative bonding claims should use the
+independent Multiwfn analyses exposed by the right-click menu, not the displayed
+structural order alone.
+
+## Sources
+
+- Multiwfn `define.f90`, `sub.f90`, `plot.f90`, and `GUI.f90` in this repository.
+- Sobereva, [discussion of deciding whether atoms are bonded](http://sobereva.com/414).
+- [GaussView element-pair threshold table](https://liuyujie714.github.io/GaussView/).
+- [3Dmol GLModel documentation](https://3dmol.org/doc/GLModel.html).

--- a/fileIO.f90
+++ b/fileIO.f90
@@ -10,6 +10,7 @@ integer infomode,inamelen
 call path2filename(thisfilename,filenameonly) !Remove folder part
 
 iresinfo=0 !First assume residue information is not available from input file (but will set to 1 in the subroutine of loading pdb/pqr/gro)
+iconnsource=0 !The reader below may set this when explicit input topology is available
 
 inamelen=len_trim(thisfilename)
 if (infomode==0) write(*,*) "Please wait..."
@@ -428,6 +429,7 @@ integer,allocatable :: shelltype6D(:) !Temporarily store Cartesian shell types c
 real*8,external :: normgau
 ifiletype=1
 imodwfn=0
+iconnsource=0
 s2f(-5,1:11)=(/ -32,-31,-30,-29,-28,-27,-26,-25,-24,-23,-22 /)
 s2f(-4,1:9)=(/ -21,-20,-19,-18,-17,-16,-15,-14,-13 /)
 s2f(-3,1:7)=(/ -12,-11,-10,-9,-8,-7,-6 /)
@@ -653,6 +655,7 @@ if (isaveNBOene==1) MOocc=0D0 !For saveNBO, the automatically determined occupat
 where (MOocc==1000) MOocc=0D0 !When saveNBO is used, the latest several occupation/energy of NBO are 1000, we modify them to zero
 where (MOene==1000) MOene=0D0
 
+call readfchconn(10,infomode)
 close(10)
 
 !!!!!! Reading have finished, now generate basis information
@@ -935,6 +938,103 @@ if (infomode==0) then
 end if
 
 call getHOMOidx !Find out index of HOMO, will be used in some cases
+end subroutine
+
+
+!!--------------------------------------------------------------------
+!! Read Gaussian's optional formal connectivity arrays from an opened
+!! formatted checkpoint file. RBond=1.5 is represented by connmat=4,
+!! consistently with the existing MOL/MOL2 aromatic-bond convention.
+subroutine readfchconn(fileid,infomode)
+use defvar
+use util
+implicit none
+integer,intent(in) :: fileid,infomode
+integer :: ifound,ierror,mxbond,nval,i,k,idx,j,itype,nbond
+integer,allocatable :: nbondatm(:),ibond(:)
+integer*2,allocatable :: directed(:,:),connread(:,:)
+real*8,allocatable :: rbond(:)
+logical,allocatable :: present(:,:)
+logical :: valid
+
+call loclabel(fileid,'MxBond',ifound)
+if (ifound==0) return
+read(fileid,"(49x,i12)",iostat=ierror) mxbond
+if (ierror/=0.or.mxbond<=0) return
+
+call loclabel(fileid,'NBond',ifound)
+if (ifound==0) return
+read(fileid,"(49x,i12)",iostat=ierror) nval
+if (ierror/=0.or.nval/=ncenter) return
+allocate(nbondatm(ncenter))
+read(fileid,"(6i12)",iostat=ierror) nbondatm
+if (ierror/=0.or.any(nbondatm<0).or.any(nbondatm>mxbond)) return
+
+call loclabel(fileid,'IBond',ifound)
+if (ifound==0) return
+read(fileid,"(49x,i12)",iostat=ierror) nval
+if (ierror/=0.or.nval/=mxbond*ncenter) return
+allocate(ibond(nval))
+read(fileid,"(6i12)",iostat=ierror) ibond
+if (ierror/=0) return
+
+call loclabel(fileid,'RBond',ifound)
+if (ifound==0) return
+read(fileid,"(49x,i12)",iostat=ierror) nval
+if (ierror/=0.or.nval/=mxbond*ncenter) return
+allocate(rbond(nval))
+read(fileid,"(5(1PE16.8))",iostat=ierror) rbond
+if (ierror/=0) return
+
+allocate(directed(ncenter,ncenter),present(ncenter,ncenter))
+directed=0
+present=.false.
+valid=.true.
+do i=1,ncenter
+    do k=1,nbondatm(i)
+        idx=(i-1)*mxbond+k
+        j=ibond(idx)
+        if (j<1.or.j>ncenter.or.j==i) then
+            valid=.false.
+            exit
+        end if
+        if (abs(rbond(idx)-1.5D0)<1D-6) then
+            itype=4
+        else if (abs(rbond(idx)-1D0)<1D-6) then
+            itype=1
+        else if (abs(rbond(idx)-2D0)<1D-6) then
+            itype=2
+        else if (abs(rbond(idx)-3D0)<1D-6) then
+            itype=3
+        else
+            valid=.false.
+            exit
+        end if
+        if (present(i,j).and.directed(i,j)/=itype) then
+            valid=.false.
+            exit
+        end if
+        present(i,j)=.true.
+        directed(i,j)=itype
+    end do
+    if (.not.valid) exit
+end do
+if (.not.valid) return
+do i=1,ncenter
+    do j=i+1,ncenter
+        if (present(i,j).neqv.present(j,i)) return
+        if (present(i,j).and.directed(i,j)/=directed(j,i)) return
+    end do
+end do
+
+allocate(connread(ncenter,ncenter))
+connread=0
+where (present) connread=directed
+if (allocated(connmat)) deallocate(connmat)
+call move_alloc(connread,connmat)
+iconnsource=1
+nbond=count(connmat/=0)/2
+if (infomode==0) write(*,"(' Loaded',i8,' explicit bonds from formatted checkpoint connectivity')") nbond
 end subroutine
 
 
@@ -2411,6 +2511,7 @@ do ibond=1,nbond
 	connmat(i,j)=ntmp
 	connmat(j,i)=ntmp
 end do
+iconnsource=1
 close(10)
 a%x=a%x/b2a
 a%y=a%y/b2a
@@ -2471,6 +2572,7 @@ do ibond=1,nbond
 	connmat(i,j)=ntmp
 	connmat(j,i)=ntmp
 end do
+iconnsource=1
 
 call loclabel(10,"@<TRIPOS>CRYSIN",ifound)
 if (ifound==1) then
@@ -2556,6 +2658,7 @@ else !Read mol
 	end do
 end if
 close(10)
+iconnsource=1
 end subroutine
 
 

--- a/frontend/3dmol-viewer/README.md
+++ b/frontend/3dmol-viewer/README.md
@@ -29,8 +29,14 @@ Implemented:
 - Draw cube slices as 2D heatmaps.
 - Load simple 2D curve and filled-map data from CSV or JSON.
 - Extract atom positions from a cube file when no separate structure is loaded.
+- Display explicit or inferred single, double, triple, aromatic, and weak bond
+  orders. Gaussian FCHK connectivity arrays and MOL/MOL2 bond records take
+  precedence. Geometry-only inputs use Multiwfn's CSD-radius connectivity
+  rule, followed by GaussView-derived order thresholds, valence constraints,
+  and aromatic-ring validation.
 - Select atoms with the right mouse button, identify bonds from 3Dmol's bond
-  topology, and annotate bond lengths and supported Multiwfn bond orders.
+  topology, and annotate displayed order, bond length, and supported Multiwfn
+  bond orders.
 - Load a JSON manifest produced by an external wrapper.
 - Export a PNG snapshot and a lightweight scene manifest.
 
@@ -151,6 +157,10 @@ length is calculated locally and does not call this endpoint.
 - `GLViewer.addModel(data, format, options)` for molecular structures.
 - `VolumeData(data, "cube")` and `GLViewer.addIsosurface(...)` for cube
   isosurfaces.
+
+The displayed structural bond-order design and its distinction from calculated
+Multiwfn bond-order values are documented in
+[`docs/3dmol_bond_order_display.md`](../../docs/3dmol_bond_order_display.md).
 
 Vendored third-party assets:
 

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -196,6 +196,7 @@ const atomSelectionColor = '#ffd400';
 const atomClickSphereRadius = 0.45;
 const bondPropertyDefinitions = [
   { id: 'length', label: 'Bond length', backend: false },
+  { id: 'display_order', label: 'Displayed bond order', backend: false },
   { id: 'mayer', label: 'Mayer', backend: true },
   { id: 'gwbo', label: 'GWBO', backend: true, openShellOnly: true },
   { id: 'wiberg_lowdin', label: 'Wiberg (Lowdin)', backend: true },
@@ -248,7 +249,7 @@ const state = {
   viewer: null,
   orientationViewer: null,
   orientationBaseView: null,
-  structure: { data: '', name: '', format: 'xyz', atoms: 0, baseData: '' },
+  structure: { data: '', name: '', format: 'xyz', atoms: 0, baseData: '', bonding: null },
   layers: [],
   periodic: {
     enabled: false,
@@ -284,6 +285,8 @@ const state = {
     orbitalRequestBusy: false,
     orbitalOpacity: 0.68,
     orbitalIsovalue: 0.015,
+    bondingThreshold: 1.15,
+    bondRenderFrame: 0,
     pendingOrbitalIndex: 0,
     manifestOrbitalLoads: new Map()
   },
@@ -658,26 +661,34 @@ function modelStyle() {
   const atomScale = toNumber(els.atomScale.value, 0.24);
   const bondRadius = toNumber(els.bondRadius.value, 0.14);
   const colorscheme = 'Jmol';
+  const stick = (radius) => ({
+    radius,
+    colorscheme,
+    aromaticStyle: 'dashed',
+    dashedBondConfig: { dashLength: 0.12, gapLength: 0.12 }
+  });
 
   if (els.modelStyle.value === 'sphere') {
     return { sphere: { scale: atomScale * 1.85, colorscheme } };
   }
   if (els.modelStyle.value === 'line') {
-    return { line: { linewidth: 2, colorscheme } };
+    // 3Dmol's line renderer omits fractional aromatic bonds. A very thin stick
+    // keeps the wireframe appearance while retaining 0.5/1.5 bond semantics.
+    return { stick: stick(Math.max(0.025, bondRadius * 0.28)) };
   }
   if (els.modelStyle.value === 'cartoon') {
     return {
       cartoon: { color: 'spectrum' },
-      stick: { radius: bondRadius * 0.72, colorscheme }
+      stick: stick(bondRadius * 0.72)
     };
   }
   if (els.modelStyle.value === 'ballstick') {
     return {
-      stick: { radius: bondRadius, colorscheme },
+      stick: stick(bondRadius),
       sphere: { scale: atomScale, colorscheme }
     };
   }
-  return { stick: { radius: bondRadius * 1.18, colorscheme } };
+  return { stick: stick(bondRadius * 1.18) };
 }
 
 function applySceneStyle() {
@@ -785,6 +796,8 @@ function makeSelectedBond(atom1, atom2) {
   const dx = Number(second.x) - Number(first.x);
   const dy = Number(second.y) - Number(first.y);
   const dz = Number(second.z) - Number(first.z);
+  const neighborPosition = Array.isArray(first.bonds) ? first.bonds.indexOf(secondIndex) : -1;
+  const displayedOrder = neighborPosition >= 0 ? Number(first.bondOrder?.[neighborPosition]) || 1 : 1;
   return {
     key: bondPairKey(firstIndex, secondIndex),
     atom1Index: firstIndex,
@@ -793,6 +806,7 @@ function makeSelectedBond(atom1, atom2) {
     atom2Name: atomDisplayName(second, secondIndex),
     label: `${atomDisplayName(first, firstIndex)}-${atomDisplayName(second, secondIndex)}`,
     length: Math.sqrt(dx * dx + dy * dy + dz * dz),
+    displayedOrder,
     atom1Position: { x: Number(first.x), y: Number(first.y), z: Number(first.z) },
     atom2Position: { x: Number(second.x), y: Number(second.y), z: Number(second.z) },
     midpoint: {
@@ -831,6 +845,10 @@ function bondPropertyDefinition(method) {
 function formatBondValue(method, value) {
   if (!Number.isFinite(Number(value))) return '';
   if (method === 'length') return `${Number(value).toFixed(4)} \u00c5`;
+  if (method === 'display_order') {
+    const labels = { 0.5: '0.5 (weak)', 1: '1 (single)', 1.5: '1.5 (aromatic)', 2: '2 (double)', 3: '3 (triple)', 4: 'aromatic' };
+    return labels[Number(value)] || String(Number(value));
+  }
   return Number(value).toFixed(6).replace(/\.?0+$/, '');
 }
 
@@ -1520,8 +1538,11 @@ function renderBondPropertyMenu(menu, bond) {
     if (property.openShellOnly && !state.bondAnalysis.capabilities.openShell) return;
     const cached = state.bondAnalysis.resultCache.get(bondResultCacheKey(bond, property.id));
     const capability = property.backend ? bondMethodCapability(property.id) : { available: true };
-    const value = property.id === 'length'
-      ? formatBondValue('length', bond.length)
+    const localValue = property.id === 'length' ? bond.length
+      : property.id === 'display_order' ? bond.displayedOrder
+        : null;
+    const value = localValue !== null
+      ? formatBondValue(property.id, localValue)
       : cached ? formatBondValue(property.id, cached.value) : '';
     const detail = cached ? bondPropertyDetail(cached) : '';
     const button = createBondMenuButton(property.label, {
@@ -1656,13 +1677,14 @@ function setBondRequestBusy(busy) {
 async function selectBondProperty(bond, method) {
   const annotation = ensureBondAnnotation(bond);
   const cached = state.bondAnalysis.resultCache.get(bondResultCacheKey(bond, method));
-  if (method === 'length') {
-    const payload = { ok: true, method, value: bond.length, components: { total: bond.length } };
+  if (method === 'length' || method === 'display_order') {
+    const value = method === 'length' ? bond.length : bond.displayedOrder;
+    const payload = { ok: true, method, value, components: { total: value } };
     state.bondAnalysis.resultCache.set(bondResultCacheKey(bond, method), payload);
     annotation.results.set(method, payload);
     renderBondAnnotation(annotation);
     syncSceneOverlays();
-    setStatus(`${bond.label} length: ${formatBondValue(method, bond.length)}`);
+    setStatus(`${bond.label} ${bondPropertyDefinition(method).label.toLowerCase()}: ${formatBondValue(method, value)}`);
     return;
   }
   if (cached) {
@@ -1746,6 +1768,74 @@ function handleAtomContextMenu(selected, x = 0, y = 0) {
   setStatus(`${action} atom ${atomDisplayName(selected, atomIndex)} (${state.atomSelection.indices.size} selected)`);
 }
 
+function applyDisplayedBondOrders(model, data, format) {
+  const perception = window.MultiwfnBondPerception;
+  if (!perception || !model || typeof model.selectedAtoms !== 'function') {
+    state.structure.bonding = null;
+    return null;
+  }
+  const atoms = model.selectedAtoms({});
+  const explicit = perception.hasExplicitBondTopology(data, format);
+  if (explicit) {
+    perception.applyExplicitBondOrders(atoms, data, format);
+    const existingStats = perception.summarizeExistingBonds(atoms);
+    const topologyOnly = ['pdb', 'pqr'].includes(String(format).toLowerCase())
+      && existingStats.total > 0
+      && existingStats.total === existingStats.single;
+    const ordered = topologyOnly
+      ? perception.assignOrdersToExistingTopology(atoms)
+      : null;
+    const result = {
+      source: topologyOnly ? 'explicit-topology' : 'explicit',
+      stats: ordered?.stats || existingStats,
+      bondingScale: null
+    };
+    state.structure.bonding = result;
+    return result;
+  }
+
+  const bondingScale = clamp(
+    toNumber(state.gui.bondingThreshold, perception.DEFAULTS.bondingScale),
+    0,
+    5
+  );
+  const perceived = perception.applyBondOrders(atoms, { bondingScale });
+  const result = {
+    source: 'inferred',
+    stats: perceived.stats,
+    bondingScale: perceived.options.bondingScale
+  };
+  state.structure.bonding = result;
+  return result;
+}
+
+function displayedBondSummary(bonding = state.structure.bonding) {
+  if (!bonding?.stats) return 'Bond topology unavailable';
+  const stats = bonding.stats;
+  const details = [
+    stats.single ? `${stats.single} single` : '',
+    stats.double ? `${stats.double} double` : '',
+    stats.triple ? `${stats.triple} triple` : '',
+    stats.aromatic ? `${stats.aromatic} aromatic` : '',
+    stats.weak ? `${stats.weak} weak` : ''
+  ].filter(Boolean).join(', ') || 'no bonds';
+  const source = bonding.source === 'explicit' ? 'Input'
+    : bonding.source === 'explicit-topology' ? 'Input topology / inferred orders'
+      : 'Inferred';
+  return `${source} bond orders: ${details}`;
+}
+
+function scheduleBondTopologyUpdate(value) {
+  state.gui.bondingThreshold = clamp(toNumber(value, 1.15), 0, 5);
+  if (state.gui.bondRenderFrame) cancelAnimationFrame(state.gui.bondRenderFrame);
+  state.gui.bondRenderFrame = requestAnimationFrame(() => {
+    state.gui.bondRenderFrame = 0;
+    clearBondAnalysisState();
+    renderScene(false);
+    setStatus(displayedBondSummary());
+  });
+}
+
 function addStructureToViewer() {
   let data = state.structure.data;
   let format = state.structure.format;
@@ -1758,6 +1848,7 @@ function addStructureToViewer() {
   try {
     const display = getDisplayStructureData(data, format);
     const model = state.viewer.addModel(display.data, display.format);
+    applyDisplayedBondOrders(model, display.data, display.format);
     model.setStyle({}, modelStyle());
     enableAtomContextSelection(model);
     if (!els.showStructure.checked) model.hide();
@@ -2608,21 +2699,22 @@ function setStructureData(text, name = 'structure.xyz', format = 'xyz', options 
     name,
     format: normalizedFormat,
     atoms: parseStructureAtomCount(text, normalizedFormat),
-    baseData: text
+    baseData: text,
+    bonding: null
   };
   state.dirtyZoom = true;
 }
 
 function loadStructure(text, name = 'structure.xyz', format = 'xyz') {
   setStructureData(text, name, format);
-  setStatus('Structure loaded');
   renderScene(true);
+  setStatus(displayedBondSummary());
 }
 
 function clearStructure() {
   clearAtomSelectionState();
   clearBondAnalysisState({ resetCapabilities: true });
-  state.structure = { data: '', name: '', format: 'xyz', atoms: 0, baseData: '' };
+  state.structure = { data: '', name: '', format: 'xyz', atoms: 0, baseData: '', bonding: null };
   state.dirtyZoom = true;
   setStatus('Structure cleared');
   renderScene(true);
@@ -2807,6 +2899,10 @@ function initialManifestLayerSpec(specs) {
 
 async function setManifestStructure(structureEntry, baseUrl) {
   if (!structureEntry) return false;
+  if (Number.isFinite(Number(structureEntry.bondingThreshold))) {
+    state.gui.bondingThreshold = clamp(Number(structureEntry.bondingThreshold), 0, 5);
+    if (els.guiBondThreshold) els.guiBondThreshold.value = String(state.gui.bondingThreshold);
+  }
   const structureData = await loadTextFromManifestEntry(structureEntry, baseUrl);
   const name = structureEntry.name || structureEntry.path || structureEntry.url || 'structure';
   setStructureData(structureData, name, structureEntry.format || detectFormat(name), {
@@ -3012,7 +3108,9 @@ function saveManifest() {
       ? {
           name: state.structure.name,
           format: state.structure.format,
-          atoms: state.structure.atoms
+          atoms: state.structure.atoms,
+          bondingThreshold: state.gui.bondingThreshold,
+          displayedBondOrders: state.structure.bonding
         }
       : null,
     layers: state.layers.map((layer) => ({
@@ -3491,8 +3589,10 @@ function syncMultiwfnGuiControls() {
   els.guiRangeA.value = els.rangeA.value;
   els.guiRangeB.value = els.rangeB.value;
   els.guiRangeC.value = els.rangeC.value;
+  if (els.guiBondSummary) els.guiBondSummary.textContent = displayedBondSummary();
 
   const atomRatio = clamp(toNumber(els.atomScale.value, 0.24) / 0.24, 0, 5);
+  els.guiBondThreshold.value = String(state.gui.bondingThreshold);
   els.guiAtomSize.value = atomRatio.toFixed(2);
   els.guiBondRadius.value = clamp(toNumber(els.bondRadius.value, 0.14) / 0.7, 0, 1).toFixed(2);
   els.guiLabelSize.value = String(state.gui.labelSize);
@@ -3799,7 +3899,7 @@ function bindEvents() {
   });
   bindRangeNumberControl(els.guiBondThreshold, els.guiBondThresholdNumber, {
     decimals: 2,
-    onInput: () => setStatus('Bonding threshold is stored for Multiwfn GUI parity')
+    onInput: (value) => scheduleBondTopologyUpdate(value)
   });
   bindRangeNumberControl(els.guiAtomSize, els.guiAtomSizeNumber, {
     decimals: 2,
@@ -4083,6 +4183,7 @@ function cacheElements() {
     guiShowSecond: byId('gui-show-second'),
     guiBondThreshold: byId('gui-bond-threshold'),
     guiBondThresholdNumber: byId('gui-bond-threshold-number'),
+    guiBondSummary: byId('gui-bond-summary'),
     guiAtomSize: byId('gui-atom-size'),
     guiAtomSizeNumber: byId('gui-atom-size-number'),
     guiBondRadius: byId('gui-bond-radius'),

--- a/frontend/3dmol-viewer/bond-perception.js
+++ b/frontend/3dmol-viewer/bond-perception.js
@@ -1,0 +1,641 @@
+(function initializeBondPerception(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.MultiwfnBondPerception = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, () => {
+  'use strict';
+
+  const SYMBOLS = [
+    '', 'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
+    'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca',
+    'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn',
+    'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr',
+    'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn',
+    'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd',
+    'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb',
+    'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg',
+    'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th',
+    'Pa', 'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm',
+    'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds',
+    'Rg', 'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og'
+  ];
+
+  // Used only to classify the order of an already connected pair. Values were
+  // recovered from the GaussView SCUtil element table in analysis.md.
+  const GAUSSVIEW_ORDER_RADII = [
+    0, 0.300, 1.160, 1.230, 0.890, 0.880, 0.770, 0.700, 0.660, 0.580, 0.550,
+    1.400, 1.360, 1.250, 1.170, 1.050, 1.010, 0.990, 1.580, 2.030, 1.740,
+    1.440, 1.320, 1.200, 1.130, 1.170, 1.160, 1.160, 1.150, 1.170, 1.250,
+    1.250, 1.220, 1.210, 1.170, 1.140, 1.890, 2.250, 1.920, 1.620, 1.450,
+    1.340, 1.290, 1.230, 1.240, 1.250, 1.280, 1.340, 1.410, 1.500, 1.400,
+    1.410, 1.370, 1.330, 2.090, 2.350, 1.980, 1.690, 1.650, 1.650, 1.640,
+    1.640, 1.660, 1.850, 1.610, 1.590, 1.590, 1.580, 1.570, 1.560, 1.700,
+    1.560, 1.440, 1.340, 1.300, 1.280, 1.260, 1.260, 1.290, 1.340, 1.440,
+    1.550, 1.540, 1.520, 1.530, 1.520, 1.530, 2.450, 2.020, 1.700, 1.630,
+    1.460, 1.400, 1.360, 1.250, 1.570, 1.580, 1.540, 1.530, 1.840, 1.610,
+    1.500, 1.490, 1.380, 1.360, 1.260, 1.200, 1.160, 1.140, 1.060, 1.280,
+    1.210, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500
+  ];
+
+  // Multiwfn's covr table (define.f90), from Dalton Trans. 2008, 2832-2838.
+  // This is the connectivity baseline used by Multiwfn's GUI and genconnmat.
+  const MULTIWFN_CSD_RADII = [
+    0, 0.31, 0.28, 1.28, 0.96, 0.84, 0.76, 0.71, 0.66, 0.57, 0.58,
+    1.66, 1.41, 1.21, 1.11, 1.07, 1.05, 1.02, 1.06, 2.03, 1.76,
+    1.70, 1.60, 1.53, 1.39, 1.39, 1.32, 1.26, 1.24, 1.32, 1.22,
+    1.22, 1.20, 1.19, 1.20, 1.20, 1.16, 2.20, 1.95, 1.90, 1.75,
+    1.64, 1.54, 1.47, 1.46, 1.42, 1.39, 1.45, 1.44, 1.42, 1.39,
+    1.39, 1.38, 1.39, 1.40, 2.44, 2.15, 2.07, 2.04, 2.03, 2.01,
+    1.99, 1.98, 1.98, 1.96, 1.94, 1.92, 1.92, 1.89, 1.90, 1.87,
+    1.87, 1.75, 1.70, 1.62, 1.51, 1.44, 1.41, 1.36, 1.36, 1.32,
+    1.45, 1.46, 1.48, 1.40, 1.50, 1.50, 2.60, 2.21, 2.15, 2.06,
+    2.00, 1.96, 1.90, 1.87, 1.80, 1.69,
+    1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50,
+    1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50, 1.50,
+    1.50, 1.50
+  ];
+
+  const ELEMENT_TO_Z = Object.fromEntries(SYMBOLS.map((symbol, z) => [symbol.toLowerCase(), z]));
+  const NOBLE_GASES = new Set([2, 10, 18, 36, 54, 86, 118]);
+  const HALOGENS = new Set([9, 17, 35, 53, 85, 117]);
+  const ALKALI_METALS = new Set([3, 11, 19, 37, 55, 87]);
+  const ALKALINE_EARTHS = new Set([4, 12, 20, 38, 56, 88]);
+  const TRANSITION_METALS = new Set([
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+    39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+    57, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+    104, 105, 106, 107, 108, 109, 110, 111, 112
+  ]);
+  const CONJUGATABLE = new Set([5, 6, 7, 8, 14, 15, 16, 32, 33, 34]);
+  const LONE_PAIR_DONORS = new Set([7, 8, 15, 16, 34]);
+
+  const DEFAULTS = Object.freeze({
+    bondingScale: 1.15,
+    weakScale: 1.50,
+    // Ratios reproduced by the element-pair table linked from analysis.md.
+    tripleScale: 0.810,
+    doubleScale: 0.900,
+    resonantScale: 0.940,
+    planarityTolerance: 0.18,
+    maxWeakBondsPerAtom: 1,
+    maxCycles: 5000
+  });
+
+  function normalizeElement(value) {
+    const text = String(value || '').trim().replace(/[^A-Za-z]/g, '');
+    if (!text) return '';
+    return `${text[0].toUpperCase()}${text.slice(1).toLowerCase()}`;
+  }
+
+  function atomicNumber(atom) {
+    const direct = Number(atom?.atomicNumber ?? atom?.atomicnum ?? atom?.atomic_number);
+    if (Number.isInteger(direct) && direct > 0 && direct < SYMBOLS.length) return direct;
+    return ELEMENT_TO_Z[normalizeElement(atom?.elem ?? atom?.element ?? atom?.atom).toLowerCase()] || 0;
+  }
+
+  function maxBondOrder(z) {
+    if (!z || NOBLE_GASES.has(z)) return 0;
+    if (z === 1 || HALOGENS.has(z) || ALKALI_METALS.has(z) || ALKALINE_EARTHS.has(z)) return 1;
+    if (z === 8 || z === 16 || z === 34) return 2;
+    return 3;
+  }
+
+  function maxCoordination(z) {
+    if (!z || NOBLE_GASES.has(z)) return 0;
+    if (z === 1 || HALOGENS.has(z)) return 1;
+    // Coordination number is not oxidation state: ionic/coordination structures
+    // routinely place more than one ligand around group 1/2 metals.
+    if (ALKALI_METALS.has(z) || ALKALINE_EARTHS.has(z)) return 8;
+    if (z === 5 || z === 7) return 3;
+    if (z === 6 || z === 14 || z === 32) return 4;
+    if (z === 8) return 2;
+    if (z === 15 || z === 33) return 5;
+    if (z === 16 || z === 34) return 6;
+    if (TRANSITION_METALS.has(z) || z >= 57 && z <= 71 || z >= 89 && z <= 103) return 8;
+    return 6;
+  }
+
+  function maxValence(z) {
+    if (!z || NOBLE_GASES.has(z)) return 0;
+    if (z === 1 || HALOGENS.has(z) || ALKALI_METALS.has(z)) return 1;
+    if (ALKALINE_EARTHS.has(z)) return 2;
+    if (z === 5) return 3;
+    if (z === 6 || z === 7 || z === 14 || z === 32) return 4;
+    if (z === 8) return 2;
+    if (z === 15 || z === 33) return 5;
+    if (z === 16 || z === 34) return 6;
+    if (TRANSITION_METALS.has(z) || z >= 57 && z <= 71 || z >= 89 && z <= 103) return 8;
+    return 6;
+  }
+
+  function distance(atom1, atom2) {
+    const dx = Number(atom2.x) - Number(atom1.x);
+    const dy = Number(atom2.y) - Number(atom1.y);
+    const dz = Number(atom2.z) - Number(atom1.z);
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+
+  function classifyCandidate(ratio, z1, z2, options) {
+    const cap = Math.min(maxBondOrder(z1), maxBondOrder(z2));
+    if (cap <= 0) return { targetOrder: 0, kind: 'none' };
+    if (ratio <= options.tripleScale && cap >= 3) {
+      return { targetOrder: 3, kind: 'triple' };
+    }
+    if (ratio <= options.doubleScale && cap >= 2) {
+      return { targetOrder: 2, kind: 'double' };
+    }
+    if (ratio <= options.resonantScale && cap >= 2) {
+      return { targetOrder: 1, kind: 'resonant-candidate' };
+    }
+    return { targetOrder: 1, kind: 'single' };
+  }
+
+  function buildCandidates(atoms, options) {
+    const prepared = atoms.map((atom, index) => ({
+      atom,
+      index,
+      z: atomicNumber(atom),
+      x: Number(atom.x),
+      y: Number(atom.y),
+      zc: Number(atom.z)
+    })).filter((entry) => (
+      entry.z > 0 && Number.isFinite(entry.x) && Number.isFinite(entry.y) && Number.isFinite(entry.zc)
+    ));
+    const sorted = [...prepared].sort((left, right) => left.x - right.x || left.index - right.index);
+    const maxConnectivityRadius = prepared.reduce((maximum, entry) => (
+      Math.max(maximum, MULTIWFN_CSD_RADII[entry.z] || 0)
+    ), 0);
+    const maxOrderRadius = prepared.reduce((maximum, entry) => (
+      Math.max(maximum, GAUSSVIEW_ORDER_RADII[entry.z] || 0)
+    ), 0);
+    const maxDistance = Math.max(
+      2 * maxConnectivityRadius * options.bondingScale,
+      2 * maxOrderRadius * options.weakScale
+    );
+    const normal = [];
+    const weak = [];
+
+    for (let leftIndex = 0; leftIndex < sorted.length; leftIndex += 1) {
+      const left = sorted[leftIndex];
+      const connectivityRadius1 = MULTIWFN_CSD_RADII[left.z];
+      const orderRadius1 = GAUSSVIEW_ORDER_RADII[left.z];
+      if (!connectivityRadius1 || !orderRadius1 || maxBondOrder(left.z) === 0) continue;
+      for (let rightIndex = leftIndex + 1; rightIndex < sorted.length; rightIndex += 1) {
+        const right = sorted[rightIndex];
+        if (right.x - left.x > maxDistance) break;
+        const connectivityRadius2 = MULTIWFN_CSD_RADII[right.z];
+        const orderRadius2 = GAUSSVIEW_ORDER_RADII[right.z];
+        if (!connectivityRadius2 || !orderRadius2 || maxBondOrder(right.z) === 0) continue;
+        const d = distance(left.atom, right.atom);
+        if (!Number.isFinite(d) || d < 0.1) continue;
+        const connectivityRatio = d / (connectivityRadius1 + connectivityRadius2);
+        const ratio = d / (orderRadius1 + orderRadius2);
+        const isNormal = connectivityRatio <= options.bondingScale;
+        if (!isNormal && ratio > options.weakScale) continue;
+        const classification = classifyCandidate(ratio, left.z, right.z, options);
+        if (!classification.targetOrder) continue;
+        const candidate = {
+          a: Math.min(left.index, right.index),
+          b: Math.max(left.index, right.index),
+          distance: d,
+          ratio,
+          connectivityRatio,
+          ...classification
+        };
+        if (isNormal) normal.push(candidate);
+        else weak.push({ ...candidate, targetOrder: 0.5, kind: 'weak' });
+      }
+    }
+    const sorter = (left, right) => (
+      left.connectivityRatio - right.connectivityRatio || left.ratio - right.ratio || left.a - right.a || left.b - right.b
+    );
+    return { normal: normal.sort(sorter), weak: weak.sort(sorter) };
+  }
+
+  function chooseConnectivity(atoms, candidates) {
+    const degree = new Array(atoms.length).fill(0);
+    const accepted = [];
+    candidates.forEach((candidate) => {
+      const z1 = atomicNumber(atoms[candidate.a]);
+      const z2 = atomicNumber(atoms[candidate.b]);
+      if (degree[candidate.a] >= maxCoordination(z1) || degree[candidate.b] >= maxCoordination(z2)) return;
+      accepted.push({ ...candidate, order: 1 });
+      degree[candidate.a] += 1;
+      degree[candidate.b] += 1;
+    });
+    return { accepted, degree };
+  }
+
+  function assignMultipleOrders(atoms, bonds, degree) {
+    const valence = [...degree];
+    const upgradeOrder = [...bonds].sort((left, right) => (
+      right.targetOrder - left.targetOrder || left.ratio - right.ratio || left.a - right.a || left.b - right.b
+    ));
+    upgradeOrder.forEach((bond) => {
+      let target = Math.min(
+        bond.targetOrder,
+        maxBondOrder(atomicNumber(atoms[bond.a])),
+        maxBondOrder(atomicNumber(atoms[bond.b]))
+      );
+      while (bond.order < target) {
+        const canRaiseA = valence[bond.a] < maxValence(atomicNumber(atoms[bond.a]));
+        const canRaiseB = valence[bond.b] < maxValence(atomicNumber(atoms[bond.b]));
+        if (!canRaiseA || !canRaiseB) break;
+        bond.order += 1;
+        valence[bond.a] += 1;
+        valence[bond.b] += 1;
+      }
+    });
+    return valence;
+  }
+
+  function edgeKey(a, b) {
+    return a < b ? `${a}:${b}` : `${b}:${a}`;
+  }
+
+  function canonicalCycle(cycle) {
+    const rotations = [];
+    const variants = [cycle, [...cycle].reverse()];
+    variants.forEach((variant) => {
+      for (let offset = 0; offset < variant.length; offset += 1) {
+        rotations.push([...variant.slice(offset), ...variant.slice(0, offset)].join(':'));
+      }
+    });
+    return rotations.sort()[0];
+  }
+
+  function findCycles(atomCount, bonds, options) {
+    const adjacency = Array.from({ length: atomCount }, () => []);
+    bonds.forEach((bond) => {
+      adjacency[bond.a].push(bond.b);
+      adjacency[bond.b].push(bond.a);
+    });
+    adjacency.forEach((neighbors) => neighbors.sort((a, b) => a - b));
+    const found = new Map();
+
+    function visit(start, current, path, visited) {
+      if (found.size >= options.maxCycles || path.length > 6) return;
+      adjacency[current].forEach((next) => {
+        if (next === start && path.length >= 5) {
+          const key = canonicalCycle(path);
+          if (!found.has(key)) found.set(key, [...path]);
+          return;
+        }
+        if (path.length >= 6 || next < start || visited.has(next)) return;
+        visited.add(next);
+        path.push(next);
+        visit(start, next, path, visited);
+        path.pop();
+        visited.delete(next);
+      });
+    }
+
+    for (let start = 0; start < atomCount && found.size < options.maxCycles; start += 1) {
+      visit(start, start, [start], new Set([start]));
+    }
+    return [...found.values()];
+  }
+
+  function ringIsPlanar(cycle, atoms, tolerance) {
+    const points = cycle.map((index) => ({
+      x: Number(atoms[index].x),
+      y: Number(atoms[index].y),
+      z: Number(atoms[index].z)
+    }));
+    const origin = points[0];
+    let normal = null;
+    for (let i = 1; i < points.length - 1 && !normal; i += 1) {
+      for (let j = i + 1; j < points.length && !normal; j += 1) {
+        const u = { x: points[i].x - origin.x, y: points[i].y - origin.y, z: points[i].z - origin.z };
+        const v = { x: points[j].x - origin.x, y: points[j].y - origin.y, z: points[j].z - origin.z };
+        const cross = {
+          x: u.y * v.z - u.z * v.y,
+          y: u.z * v.x - u.x * v.z,
+          z: u.x * v.y - u.y * v.x
+        };
+        const length = Math.hypot(cross.x, cross.y, cross.z);
+        if (length > 1e-6) normal = { x: cross.x / length, y: cross.y / length, z: cross.z / length };
+      }
+    }
+    if (!normal) return false;
+    return points.every((point) => Math.abs(
+      (point.x - origin.x) * normal.x +
+      (point.y - origin.y) * normal.y +
+      (point.z - origin.z) * normal.z
+    ) <= tolerance);
+  }
+
+  function aromaticContribution(atomIndex, cycle, atoms, adjacency, edgeMap) {
+    const position = cycle.indexOf(atomIndex);
+    const previous = cycle[(position + cycle.length - 1) % cycle.length];
+    const next = cycle[(position + 1) % cycle.length];
+    const ringBonds = [edgeMap.get(edgeKey(atomIndex, previous)), edgeMap.get(edgeKey(atomIndex, next))];
+    const z = atomicNumber(atoms[atomIndex]);
+    if (!CONJUGATABLE.has(z)) return null;
+
+    const hasMultiple = ringBonds.some((bond) => bond && bond.targetOrder >= 2);
+    const hasResonantGeometry = ringBonds.some((bond) => bond?.kind === 'resonant-candidate');
+    const exocyclicNeighbors = adjacency[atomIndex].filter((neighbor) => neighbor !== previous && neighbor !== next);
+    const donorGeometry = LONE_PAIR_DONORS.has(z) && !hasMultiple && (
+      z === 8 || z === 16 || z === 34 || exocyclicNeighbors.length > 0
+    );
+    if (donorGeometry) return 2;
+    if (hasMultiple || hasResonantGeometry) return 1;
+    if (z === 5) return 0;
+    return null;
+  }
+
+  function assignAromaticOrders(atoms, bonds, options) {
+    const edgeMap = new Map(bonds.map((bond) => [edgeKey(bond.a, bond.b), bond]));
+    const adjacency = Array.from({ length: atoms.length }, () => []);
+    bonds.forEach((bond) => {
+      adjacency[bond.a].push(bond.b);
+      adjacency[bond.b].push(bond.a);
+    });
+    const conjugatableBonds = bonds.filter((bond) => (
+      CONJUGATABLE.has(atomicNumber(atoms[bond.a])) && CONJUGATABLE.has(atomicNumber(atoms[bond.b]))
+    ));
+    const cycles = findCycles(atoms.length, conjugatableBonds, options);
+    let aromaticRings = 0;
+    cycles.forEach((cycle) => {
+      if (!ringIsPlanar(cycle, atoms, options.planarityTolerance)) return;
+      const contributions = cycle.map((atomIndex) => (
+        aromaticContribution(atomIndex, cycle, atoms, adjacency, edgeMap)
+      ));
+      if (contributions.some((value) => value === null)) return;
+      const piElectrons = contributions.reduce((sum, value) => sum + value, 0);
+      if (piElectrons < 2 || (piElectrons - 2) % 4 !== 0) return;
+      aromaticRings += 1;
+      cycle.forEach((atomIndex, position) => {
+        const next = cycle[(position + 1) % cycle.length];
+        const bond = edgeMap.get(edgeKey(atomIndex, next));
+        if (bond && bond.order < 3) {
+          bond.order = 1.5;
+          bond.kind = 'aromatic';
+        }
+      });
+    });
+    return aromaticRings;
+  }
+
+  class DisjointSet {
+    constructor(size) {
+      this.parent = Array.from({ length: size }, (_, index) => index);
+      this.rank = new Array(size).fill(0);
+    }
+
+    find(value) {
+      if (this.parent[value] !== value) this.parent[value] = this.find(this.parent[value]);
+      return this.parent[value];
+    }
+
+    union(left, right) {
+      let rootLeft = this.find(left);
+      let rootRight = this.find(right);
+      if (rootLeft === rootRight) return false;
+      if (this.rank[rootLeft] < this.rank[rootRight]) [rootLeft, rootRight] = [rootRight, rootLeft];
+      this.parent[rootRight] = rootLeft;
+      if (this.rank[rootLeft] === this.rank[rootRight]) this.rank[rootLeft] += 1;
+      return true;
+    }
+  }
+
+  function addWeakBonds(atomCount, normalBonds, weakCandidates, options) {
+    const components = new DisjointSet(atomCount);
+    normalBonds.forEach((bond) => components.union(bond.a, bond.b));
+    const weakDegree = new Array(atomCount).fill(0);
+    const accepted = [];
+    weakCandidates.forEach((candidate) => {
+      if (components.find(candidate.a) === components.find(candidate.b)) return;
+      if (
+        weakDegree[candidate.a] >= options.maxWeakBondsPerAtom ||
+        weakDegree[candidate.b] >= options.maxWeakBondsPerAtom
+      ) return;
+      accepted.push({ ...candidate, order: 0.5 });
+      weakDegree[candidate.a] += 1;
+      weakDegree[candidate.b] += 1;
+      components.union(candidate.a, candidate.b);
+    });
+    return accepted;
+  }
+
+  function perceiveBondOrders(atoms, suppliedOptions = {}) {
+    const options = { ...DEFAULTS, ...suppliedOptions };
+    const bondingScale = Number(options.bondingScale);
+    const weakScale = Number(options.weakScale);
+    options.bondingScale = Number.isFinite(bondingScale)
+      ? Math.max(0, bondingScale)
+      : DEFAULTS.bondingScale;
+    options.weakScale = Math.max(
+      options.bondingScale,
+      Number.isFinite(weakScale) ? weakScale : DEFAULTS.weakScale
+    );
+    const candidates = buildCandidates(atoms, options);
+    if (options.bondingScale === 0) candidates.weak = [];
+    const { accepted: normalBonds, degree } = chooseConnectivity(atoms, candidates.normal);
+    assignMultipleOrders(atoms, normalBonds, degree);
+    const aromaticRings = assignAromaticOrders(atoms, normalBonds, options);
+    const weakBonds = addWeakBonds(atoms.length, normalBonds, candidates.weak, options);
+    const bonds = [...normalBonds, ...weakBonds].sort((left, right) => left.a - right.a || left.b - right.b);
+    return {
+      bonds,
+      stats: {
+        total: bonds.length,
+        single: bonds.filter((bond) => bond.order === 1).length,
+        double: bonds.filter((bond) => bond.order === 2).length,
+        triple: bonds.filter((bond) => bond.order === 3).length,
+        aromatic: bonds.filter((bond) => bond.order === 1.5).length,
+        weak: bonds.filter((bond) => bond.order === 0.5).length,
+        aromaticRings
+      },
+      options
+    };
+  }
+
+  function applyBondOrders(atoms, suppliedOptions = {}) {
+    const result = perceiveBondOrders(atoms, suppliedOptions);
+    atoms.forEach((atom) => {
+      atom.bonds = [];
+      atom.bondOrder = [];
+    });
+    result.bonds.forEach((bond) => {
+      atoms[bond.a].bonds.push(bond.b);
+      atoms[bond.a].bondOrder.push(bond.order);
+      atoms[bond.b].bonds.push(bond.a);
+      atoms[bond.b].bondOrder.push(bond.order);
+    });
+    return result;
+  }
+
+  function assignOrdersToExistingTopology(atoms, suppliedOptions = {}) {
+    const options = { ...DEFAULTS, ...suppliedOptions };
+    const bonds = [];
+    const degree = new Array(atoms.length).fill(0);
+    atoms.forEach((atom, atomIndex) => {
+      (atom.bonds || []).forEach((neighborValue) => {
+        const neighbor = Number(neighborValue);
+        if (!Number.isInteger(neighbor) || atomIndex >= neighbor || !atoms[neighbor]) return;
+        const z1 = atomicNumber(atom);
+        const z2 = atomicNumber(atoms[neighbor]);
+        const d = distance(atom, atoms[neighbor]);
+        const radiusSum = (GAUSSVIEW_ORDER_RADII[z1] || 0) + (GAUSSVIEW_ORDER_RADII[z2] || 0);
+        if (!radiusSum || !Number.isFinite(d)) return;
+        const ratio = d / radiusSum;
+        bonds.push({
+          a: atomIndex,
+          b: neighbor,
+          distance: d,
+          ratio,
+          connectivityRatio: null,
+          ...classifyCandidate(ratio, z1, z2, options),
+          order: 1
+        });
+        degree[atomIndex] += 1;
+        degree[neighbor] += 1;
+      });
+    });
+    bonds.sort((left, right) => left.ratio - right.ratio || left.a - right.a || left.b - right.b);
+    assignMultipleOrders(atoms, bonds, degree);
+    const aromaticRings = assignAromaticOrders(atoms, bonds, options);
+    const orderByEdge = new Map(bonds.map((bond) => [edgeKey(bond.a, bond.b), bond.order]));
+    atoms.forEach((atom, atomIndex) => {
+      atom.bondOrder = (atom.bonds || []).map((neighbor) => (
+        orderByEdge.get(edgeKey(atomIndex, Number(neighbor))) || 1
+      ));
+    });
+    return {
+      bonds,
+      stats: {
+        total: bonds.length,
+        single: bonds.filter((bond) => bond.order === 1).length,
+        double: bonds.filter((bond) => bond.order === 2).length,
+        triple: bonds.filter((bond) => bond.order === 3).length,
+        aromatic: bonds.filter((bond) => bond.order === 1.5).length,
+        weak: 0,
+        aromaticRings
+      },
+      options
+    };
+  }
+
+  function hasExplicitBondTopology(data, format) {
+    const text = String(data || '');
+    const normalized = String(format || '').toLowerCase().replace(/\.gz$/, '');
+    if (normalized === 'sdf' || normalized === 'mol') {
+      const lines = text.split(/\r?\n/);
+      const v3000Counts = lines.find((line) => /^M\s+V30\s+COUNTS\s+/i.test(line));
+      if (v3000Counts) {
+        const fields = v3000Counts.trim().split(/\s+/);
+        const bondCount = Number.parseInt(fields[4], 10);
+        return Number.isFinite(bondCount) && bondCount > 0;
+      }
+      const countLine = lines[3] || '';
+      const bondCount = Number.parseInt(countLine.slice(3, 6), 10);
+      return Number.isFinite(bondCount) && bondCount > 0;
+    }
+    if (normalized === 'mol2') {
+      const block = text.match(/@<TRIPOS>BOND\s*([\s\S]*?)(?:@<TRIPOS>|$)/i);
+      return Boolean(block && block[1].split(/\r?\n/).some((line) => /^\s*\d+\s+\d+\s+\d+\s+\S+/.test(line)));
+    }
+    if (normalized === 'pdb' || normalized === 'pqr') return /^CONECT\s+/m.test(text);
+    if (normalized === 'cif') return /_(?:geom|chem_comp)_bond_/i.test(text);
+    return false;
+  }
+
+  function normalizeExplicitOrder(value) {
+    const text = String(value || '').trim().toLowerCase();
+    if (text === 'ar') return 1.5;
+    const order = Number(text);
+    if (!Number.isFinite(order) || order <= 0) return null;
+    return order === 4 ? 1.5 : order;
+  }
+
+  function explicitOrdersFromMol2(text) {
+    const atomBlock = text.match(/@<TRIPOS>ATOM\s*([\s\S]*?)(?:@<TRIPOS>|$)/i);
+    const bondBlock = text.match(/@<TRIPOS>BOND\s*([\s\S]*?)(?:@<TRIPOS>|$)/i);
+    if (!bondBlock) return [];
+    const atomIds = new Map();
+    (atomBlock?.[1] || '').split(/\r?\n/).forEach((line) => {
+      const fields = line.trim().split(/\s+/);
+      const id = Number.parseInt(fields[0], 10);
+      if (Number.isInteger(id)) atomIds.set(id, atomIds.size);
+    });
+    return bondBlock[1].split(/\r?\n/).flatMap((line) => {
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 4) return [];
+      const firstId = Number.parseInt(fields[1], 10);
+      const secondId = Number.parseInt(fields[2], 10);
+      const order = normalizeExplicitOrder(fields[3]);
+      const a = atomIds.has(firstId) ? atomIds.get(firstId) : firstId - 1;
+      const b = atomIds.has(secondId) ? atomIds.get(secondId) : secondId - 1;
+      return Number.isInteger(a) && Number.isInteger(b) && order ? [{ a, b, order }] : [];
+    });
+  }
+
+  function explicitOrdersFromMol(text) {
+    const lines = text.split(/\r?\n/);
+    const atomCount = Number.parseInt((lines[3] || '').slice(0, 3), 10);
+    const bondCount = Number.parseInt((lines[3] || '').slice(3, 6), 10);
+    if (!Number.isInteger(atomCount) || !Number.isInteger(bondCount)) return [];
+    return lines.slice(4 + atomCount, 4 + atomCount + bondCount).flatMap((line) => {
+      const a = Number.parseInt(line.slice(0, 3), 10) - 1;
+      const b = Number.parseInt(line.slice(3, 6), 10) - 1;
+      const order = normalizeExplicitOrder(line.slice(6, 9));
+      return Number.isInteger(a) && Number.isInteger(b) && order ? [{ a, b, order }] : [];
+    });
+  }
+
+  function applyExplicitBondOrders(atoms, data, format) {
+    const normalized = String(format || '').toLowerCase().replace(/\.gz$/, '');
+    const text = String(data || '');
+    const orders = normalized === 'mol2'
+      ? explicitOrdersFromMol2(text)
+      : ['sdf', 'mol'].includes(normalized) ? explicitOrdersFromMol(text) : [];
+    let applied = 0;
+    orders.forEach(({ a, b, order }) => {
+      if (!atoms[a] || !atoms[b]) return;
+      const aBond = (atoms[a].bonds || []).findIndex((neighbor) => Number(neighbor) === b);
+      const bBond = (atoms[b].bonds || []).findIndex((neighbor) => Number(neighbor) === a);
+      if (aBond < 0 || bBond < 0) return;
+      if (!Array.isArray(atoms[a].bondOrder)) atoms[a].bondOrder = [];
+      if (!Array.isArray(atoms[b].bondOrder)) atoms[b].bondOrder = [];
+      atoms[a].bondOrder[aBond] = order;
+      atoms[b].bondOrder[bBond] = order;
+      applied += 1;
+    });
+    return applied;
+  }
+
+  function summarizeExistingBonds(atoms) {
+    const orders = [];
+    atoms.forEach((atom, atomIndex) => {
+      (atom.bonds || []).forEach((neighbor, bondIndex) => {
+        if (atomIndex >= Number(neighbor)) return;
+        orders.push(Number(atom.bondOrder?.[bondIndex]) || 1);
+      });
+    });
+    return {
+      total: orders.length,
+      single: orders.filter((order) => order === 1).length,
+      double: orders.filter((order) => order === 2).length,
+      triple: orders.filter((order) => order === 3).length,
+      aromatic: orders.filter((order) => order === 1.5 || order === 4).length,
+      weak: orders.filter((order) => order === 0.5).length,
+      aromaticRings: 0
+    };
+  }
+
+  return Object.freeze({
+    DEFAULTS,
+    COVALENT_RADII: GAUSSVIEW_ORDER_RADII,
+    GAUSSVIEW_ORDER_RADII,
+    MULTIWFN_CSD_RADII,
+    atomicNumber,
+    hasExplicitBondTopology,
+    applyExplicitBondOrders,
+    perceiveBondOrders,
+    applyBondOrders,
+    assignOrdersToExistingTopology,
+    summarizeExistingBonds
+  });
+}));

--- a/frontend/3dmol-viewer/index.html
+++ b/frontend/3dmol-viewer/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="modern.css">
     <script defer src="vendor/3Dmol-min.js"></script>
     <script defer src="cube-coordinates.js"></script>
+    <script defer src="bond-perception.js"></script>
     <script defer src="app.js"></script>
   </head>
   <body>
@@ -82,6 +83,7 @@
                   </span>
                 </label>
               </div>
+              <div id="gui-bond-summary" class="orbital-status">Bond topology pending</div>
             </div>
 
             <div class="group orbital-panel">

--- a/frontend/3dmol-viewer/tests/bond-perception.test.js
+++ b/frontend/3dmol-viewer/tests/bond-perception.test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const perception = require('../bond-perception.js');
+
+function atom(elem, x, y = 0, z = 0) {
+  return { elem, x, y, z };
+}
+
+function regularRing(elements, side, zAt = () => 0) {
+  const radius = side / (2 * Math.sin(Math.PI / elements.length));
+  return elements.map((elem, index) => {
+    const angle = 2 * Math.PI * index / elements.length;
+    return atom(elem, radius * Math.cos(angle), radius * Math.sin(angle), zAt(index));
+  });
+}
+
+function onlyOrder(atoms) {
+  const result = perception.perceiveBondOrders(atoms);
+  assert.equal(result.bonds.length, 1);
+  return result.bonds[0].order;
+}
+
+test('classifies representative single, double, and triple bonds', () => {
+  assert.equal(onlyOrder([atom('C', 0), atom('C', 1.54)]), 1);
+  assert.equal(onlyOrder([atom('C', 0), atom('C', 1.34)]), 2);
+  assert.equal(onlyOrder([atom('C', 0), atom('C', 1.20)]), 3);
+  assert.equal(onlyOrder([atom('N', 0), atom('N', 1.10)]), 3);
+  assert.equal(onlyOrder([atom('C', 0), atom('O', 1.21)]), 2);
+});
+
+test('applies the default order thresholds without an added tolerance', () => {
+  const carbonRadiusSum = 1.54;
+  assert.equal(onlyOrder([atom('C', 0), atom('C', carbonRadiusSum * 0.9000)]), 2);
+  assert.equal(onlyOrder([atom('C', 0), atom('C', carbonRadiusSum * 0.9002)]), 1);
+});
+
+test('caps hydrogen and halogen pairs at single order', () => {
+  assert.equal(onlyOrder([atom('H', 0), atom('H', 0.50)]), 1);
+  assert.equal(onlyOrder([atom('C', 0), atom('F', 0.90)]), 1);
+});
+
+test('uses valence to choose one double bond at a two-coordinate nitrogen', () => {
+  const result = perception.perceiveBondOrders([
+    atom('C', -1.323),
+    atom('N', 0),
+    atom('C', 1.325)
+  ]);
+  assert.equal(result.stats.double, 1);
+  assert.equal(result.stats.single, 1);
+});
+
+test('uses the Multiwfn CSD connectivity criterion for Pt-N', () => {
+  const result = perception.perceiveBondOrders([atom('Pt', 0), atom('N', 2.20)]);
+  assert.equal(result.bonds.length, 1);
+  assert.equal(result.bonds[0].order, 1);
+  assert.ok(result.bonds[0].connectivityRatio < 1.15);
+});
+
+test('recognizes a planar six-membered resonant ring as aromatic', () => {
+  const result = perception.perceiveBondOrders(regularRing(Array(6).fill('C'), 1.40));
+  assert.equal(result.stats.aromaticRings, 1);
+  assert.equal(result.stats.aromatic, 6);
+  assert.ok(result.bonds.every((bond) => bond.order === 1.5));
+});
+
+test('recognizes a five-membered heteroaromatic ring with a lone-pair donor', () => {
+  const result = perception.perceiveBondOrders(regularRing(['O', 'C', 'C', 'C', 'C'], 1.38));
+  assert.equal(result.stats.aromaticRings, 1);
+  assert.equal(result.stats.aromatic, 5);
+});
+
+test('does not label a puckered saturated ring aromatic', () => {
+  const ring = regularRing(Array(6).fill('C'), 1.53, (index) => index % 2 ? 0.28 : -0.28);
+  const result = perception.perceiveBondOrders(ring);
+  assert.equal(result.stats.aromaticRings, 0);
+  assert.equal(result.stats.aromatic, 0);
+});
+
+test('keeps weak bonds only between otherwise disconnected components', () => {
+  const isolated = perception.perceiveBondOrders([atom('C', 0), atom('C', 2.0)]);
+  assert.equal(isolated.stats.weak, 1);
+  assert.equal(isolated.bonds[0].order, 0.5);
+
+  const triangle = perception.perceiveBondOrders([
+    atom('C', 0, 0),
+    atom('C', 1, 1.174),
+    atom('C', 2, 0)
+  ]);
+  assert.equal(triangle.stats.weak, 0);
+  assert.equal(triangle.stats.single, 2);
+});
+
+test('honors a zero bonding threshold as no displayed bonds', () => {
+  const result = perception.perceiveBondOrders([atom('C', 0), atom('C', 1.34)], { bondingScale: 0 });
+  assert.equal(result.stats.total, 0);
+});
+
+test('writes reciprocal 3Dmol bond and bondOrder arrays', () => {
+  const atoms = [atom('C', 0), atom('C', 1.34)];
+  perception.applyBondOrders(atoms);
+  assert.deepEqual(atoms[0].bonds, [1]);
+  assert.deepEqual(atoms[1].bonds, [0]);
+  assert.deepEqual(atoms[0].bondOrder, [2]);
+  assert.deepEqual(atoms[1].bondOrder, [2]);
+});
+
+test('infers orders without replacing explicit topology-only bonds', () => {
+  const atoms = [
+    { ...atom('C', 0), bonds: [1], bondOrder: [1] },
+    { ...atom('C', 1.34), bonds: [0], bondOrder: [1] }
+  ];
+  const result = perception.assignOrdersToExistingTopology(atoms);
+  assert.equal(result.stats.double, 1);
+  assert.deepEqual(atoms[0].bonds, [1]);
+  assert.deepEqual(atoms[1].bonds, [0]);
+  assert.deepEqual(atoms[0].bondOrder, [2]);
+  assert.deepEqual(atoms[1].bondOrder, [2]);
+});
+
+test('detects explicit topology in supported structure formats', () => {
+  const sdf = ['mol', 'source', '', '  2  1  0  0  0  0            999 V2000'].join('\n');
+  const sdfV3000 = ['mol', 'source', '', '  0  0  0     0  0            999 V3000', 'M  V30 COUNTS 2 1 0 0 0'].join('\n');
+  const mol2 = '@<TRIPOS>BOND\n     1     1     2 2\n@<TRIPOS>SUBSTRUCTURE\n';
+  const pdb = 'ATOM      1  C   MOL A   1       0.000   0.000   0.000\nCONECT    1    2\n';
+  assert.equal(perception.hasExplicitBondTopology(sdf, 'sdf'), true);
+  assert.equal(perception.hasExplicitBondTopology(sdfV3000, 'sdf'), true);
+  assert.equal(perception.hasExplicitBondTopology(mol2, 'mol2'), true);
+  assert.equal(perception.hasExplicitBondTopology(pdb, 'pdb'), true);
+  assert.equal(perception.hasExplicitBondTopology('2\nplain xyz\nC 0 0 0\nC 1.3 0 0\n', 'xyz'), false);
+});
+
+test('restores aromatic MOL2 orders that 3Dmol parses as single', () => {
+  const atoms = [
+    { bonds: [1], bondOrder: [1] },
+    { bonds: [0], bondOrder: [1] }
+  ];
+  const mol2 = [
+    '@<TRIPOS>ATOM',
+    '1 C1 0 0 0 C',
+    '2 C2 1 0 0 C',
+    '@<TRIPOS>BOND',
+    '1 1 2 ar'
+  ].join('\n');
+  assert.equal(perception.applyExplicitBondOrders(atoms, mol2, 'mol2'), 1);
+  assert.deepEqual(atoms.map((entry) => entry.bondOrder), [[1.5], [1.5]]);
+  assert.equal(perception.summarizeExistingBonds(atoms).aromatic, 1);
+});

--- a/noGUI/GUI_3dmol.f90
+++ b/noGUI/GUI_3dmol.f90
@@ -100,7 +100,13 @@ call ensure_dir(session)
 call remove_session_file(trim(session)//"/gui_stop.flag")
 call remove_session_file(trim(session)//"/gui_request.txt")
 
-if (allocated(a).and.ncenter>0) call write_structure_xyz(trim(session)//"/structure.xyz")
+if (allocated(a).and.ncenter>0) then
+    if (iconnsource==1.and.allocated(connmat).and.size(connmat,1)==ncenter.and.size(connmat,2)==ncenter) then
+        call write_structure_mol2(trim(session)//"/structure.mol2")
+    else
+        call write_structure_xyz(trim(session)//"/structure.xyz")
+    end if
+end if
 if (allocated(cubmat)) then
     call write_cube(trim(session)//"/cubmat.cube",cubmat)
     gui_has_cubmat_file=.true.
@@ -716,6 +722,43 @@ end do
 close(iu)
 end subroutine
 
+subroutine write_structure_mol2(path)
+character(len=*),intent(in) :: path
+integer :: iu,i,j,ibond,nbond
+character(len=24) :: atomlabel
+character(len=8) :: bondtype
+
+nbond=count(connmat/=0)/2
+open(newunit=iu,file=trim(path),status="replace",action="write")
+write(iu,"(a)") "@<TRIPOS>MOLECULE"
+write(iu,"(a)") "Generated_by_Multiwfn_3Dmol_GUI_backend"
+write(iu,"(2(i0,1x))") ncenter,nbond
+write(iu,"(a)") "SMALL"
+write(iu,"(a)") "NO_CHARGES"
+write(iu,*)
+write(iu,"(a)") "@<TRIPOS>ATOM"
+do i=1,ncenter
+    write(atomlabel,"(a,i0)") trim(a(i)%name),i
+    write(iu,"(i0,1x,a,3(1x,f18.10),1x,a,1x,i0,1x,a,1x,f8.4)") &
+        i,trim(atomlabel),a(i)%x*b2a,a(i)%y*b2a,a(i)%z*b2a,trim(a(i)%name),1,"MOL",0D0
+end do
+write(iu,"(a)") "@<TRIPOS>BOND"
+ibond=0
+do i=1,ncenter
+    do j=i+1,ncenter
+        if (connmat(i,j)==0) cycle
+        ibond=ibond+1
+        if (connmat(i,j)==4) then
+            bondtype="ar"
+        else
+            write(bondtype,"(i0)") connmat(i,j)
+        end if
+        write(iu,"(3(i0,1x),a)") ibond,i,j,trim(bondtype)
+    end do
+end do
+close(iu)
+end subroutine
+
 subroutine write_cube(path,data)
 character(len=*),intent(in) :: path
 real*8,intent(in) :: data(:,:,:)
@@ -777,7 +820,11 @@ write(iu,"(a,1pe16.8,a,1pe16.8,a,1pe16.8,a,1pe16.8,a,1pe16.8,a,1pe16.8,a)") &
 write(iu,"(a)") '    }'
 write(iu,"(a)") '  },'
 if (allocated(a).and.ncenter>0) then
-    write(iu,"(a)") '  "structure": { "path": "structure.xyz", "format": "xyz" },'
+    if (iconnsource==1.and.allocated(connmat).and.size(connmat,1)==ncenter.and.size(connmat,2)==ncenter) then
+        write(iu,"(a)") '  "structure": { "path": "structure.mol2", "format": "mol2" },'
+    else
+        write(iu,"(a)") '  "structure": { "path": "structure.xyz", "format": "xyz" },'
+    end if
 else
     write(iu,"(a)") '  "structure": null,'
 end if

--- a/sub.f90
+++ b/sub.f90
@@ -2857,6 +2857,7 @@ if (allocated(MOsym)) deallocate(MOsym)
 if (allocated(MOene)) deallocate(MOene)
 if (allocated(MOtype)) deallocate(MOtype)
 if (allocated(connmat)) deallocate(connmat)
+iconnsource=0
 if (allocated(bndordmat)) deallocate(bndordmat)
 !Related to basis functions
 if (allocated(shtype)) deallocate(shtype,shcen,shcon,primshexp,primshcoeff)
@@ -4313,6 +4314,7 @@ integer infomode,iallowPBC
 if (allocated(a)) then
     if (allocated(connmat)) deallocate(connmat)
     allocate(connmat(ncenter,ncenter))
+    iconnsource=2
     if (infomode==1) then
 		write(*,*) "Generating bonding relationship..."
 		write(*,"(a,f5.3,a)") " Note: If distance between two atoms is smaller than sum of their &


### PR DESCRIPTION
## Summary

- Preserve validated formal connectivity from Gaussian FCHK files and existing MOL/MOL2 topology, exporting explicit structures to 3Dmol as MOL2.
- Infer structural bond orders only when explicit topology is unavailable, using Multiwfn CSD radii for connectivity and GaussView-derived order thresholds with valence, aromatic-ring, and weak-bond cleanup.
- Render single, double, triple, aromatic, and weak bonds in 3Dmol, and expose the displayed structural order separately from calculated Mayer, GWBO, Wiberg, Mulliken, and FBO values.
- Document data precedence, perception rules, validation, and limitations.

The default 0.9000 double-bond threshold is applied directly; this PR does not add a molecule-specific tolerance.

## Testing

- `node --test frontend/3dmol-viewer/tests/bond-perception.test.js frontend/3dmol-viewer/tests/cube-coordinates.test.js` — 20/20 passed.
- Configured and built the complete 3Dmol Fortran backend with CMake/Ninja on macOS.
- Loaded `PcG0.fchk` through Multiwfn 2026.7.10 and detected all 86 explicit bonds.
- Compared the exported MOL2 topology against FCHK `IBond/RBond`: 37 single, 2 double, and 47 aromatic bonds, with zero mismatches.
- `git diff --check upstream/main...HEAD` passed.

## Scope

This PR contains only displayed bond-order functionality and its tests/documentation. It excludes the unrelated measurement, camera, object-tree, renderer-evaluation, and Qt notification experiments.