### PR TITLE
Add interactive ESP analysis and extrema visualization

### DIFF
--- a/frontend/3dmol-viewer/README.md
+++ b/frontend/3dmol-viewer/README.md
@@ -34,9 +34,17 @@ Implemented:
   precedence. Geometry-only inputs use Multiwfn's CSD-radius connectivity
   rule, followed by GaussView-derived order thresholds, valence constraints,
   and aromatic-ring validation.
-- Select atoms with the right mouse button, identify bonds from 3Dmol's bond
-  topology, and annotate displayed order, bond length, and supported Multiwfn
-  bond orders.
+- Select atoms with Command-click on macOS or Ctrl-click on Windows/Linux,
+  identify bonds from 3Dmol's bond topology, and use right-click menus to
+  annotate displayed order, bond length, and supported Multiwfn bond orders.
+- Open the Tools > Electrostatic potential submenu to request a live Multiwfn
+  ESP calculation, adjust the existing surface opacity in place, and map the
+  potential onto the 0.001 a.u. electron-density surface with a
+  pink-white-blue trans-flag gradient.
+- Toggle local ESP surface minima and maxima from the same submenu. Extrema are
+  extracted in a worker from the current density/ESP cube pair, candidates at
+  the cube boundary are rejected, and a clicked marker reports its a.u. and
+  kcal/mol values without rebuilding the isosurface.
 - Load a JSON manifest produced by an external wrapper.
 - Export a PNG snapshot and a lightweight scene manifest.
 
@@ -150,6 +158,12 @@ The generated GUI service exposes bond orders through
 `GET /api/bond?atom1=1&atom2=2&method=mayer`. Atom indices are one-based and
 the response contains `value` plus spin components when applicable. Bond
 length is calculated locally and does not call this endpoint.
+
+Live non-periodic wavefunction sessions also expose
+`GET /api/esp?quality=120000&isovalue=0.001`. The response references matching
+density and ESP cube files. Repeating the same request in the frontend uses the
+current session cache; changing the active quality requests a fresh pair from
+Multiwfn. Periodic and structure-only sessions report ESP as unavailable.
 
 3Dmol.js references used while implementing this prototype:
 

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -361,6 +361,11 @@ const state = {
     isovalue: 0.001,
     opacity: 0.88,
     opacityFrame: 0,
+    legend: {
+      enabled: true,
+      position: null,
+      drag: null
+    },
     extrema: {
       enabled: false,
       busy: false,
@@ -2152,6 +2157,7 @@ function renderScene(zoom = false) {
   updateLabels();
   updateStats();
   syncMultiwfnGuiControls();
+  syncEspLegendVisibility();
 }
 
 function updateLabels() {
@@ -2724,7 +2730,12 @@ function toolsMenuButtons() {
 }
 
 function espToolsMenuControls() {
-  return [els.guiToolEspShow, els.guiToolEspExtrema, els.guiEspOpacity].filter(Boolean);
+  return [
+    els.guiToolEspShow,
+    els.guiToolEspLegend,
+    els.guiToolEspExtrema,
+    els.guiEspOpacity
+  ].filter(Boolean);
 }
 
 function closeEspToolsMenu(options = {}) {
@@ -2741,6 +2752,7 @@ function setEspToolsMenuOpen(open, options = {}) {
   els.guiToolEsp.setAttribute('aria-expanded', String(isOpen));
   if (!isOpen) return;
   syncEspOpacityControls();
+  syncEspLegendVisibility();
   positionStyleSubmenu(els.guiToolEsp, els.guiEspMenu);
   if (options.focus) requestAnimationFrame(() => espToolsMenuControls()[0]?.focus());
 }
@@ -2948,6 +2960,7 @@ function removeEspAnalysisLayers(options = {}) {
   renderLayerList();
   updateLayerSelectors();
   syncEspOpacityControls();
+  syncEspLegendVisibility();
   return removedIds.size > 0;
 }
 
@@ -2962,6 +2975,203 @@ function espExtremaPoints(result = state.espAnalysis.extrema.result) {
 
 function isPlotPanelVisible() {
   return Boolean(els.plotPanel && !els.plotPanel.classList.contains('is-hidden'));
+}
+
+function currentEspLegendModel() {
+  const density = espLayerByKind('esp-density');
+  if (!density) return null;
+  const min = Number(density.colorMin);
+  const max = Number(density.colorMax);
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) return null;
+  const gradient = makeGradient(density.gradient || 'trans', min, max);
+  const ticks = espScale?.espLegendTicks(min, max, 5) || [];
+  if (!ticks.length) return null;
+  return {
+    layerId: String(density.id),
+    min,
+    max,
+    gradient,
+    ticks
+  };
+}
+
+function espLegendColorHex(model, value) {
+  let color = 0xffffff;
+  try {
+    color = model.gradient.valueToHex(value, [model.min, model.max]);
+  } catch (error) {
+    console.error(error);
+  }
+  if (typeof color === 'string') {
+    const normalized = color.trim();
+    if (/^#[0-9a-f]{6}$/i.test(normalized)) return normalized;
+    if (/^[0-9a-f]{6}$/i.test(normalized)) return `#${normalized}`;
+  }
+  const numeric = Number(color);
+  return Number.isFinite(numeric)
+    ? `#${(numeric & 0xffffff).toString(16).padStart(6, '0')}`
+    : '#ffffff';
+}
+
+function paintEspLegendGradient(context, model, x, y, width, height) {
+  const rows = Math.max(1, Math.ceil(height));
+  for (let row = 0; row < rows; row += 1) {
+    const fraction = rows === 1 ? 0 : row / (rows - 1);
+    const value = model.max + fraction * (model.min - model.max);
+    context.fillStyle = espLegendColorHex(model, value);
+    context.fillRect(x, y + row * height / rows, width, Math.max(1, height / rows + 0.5));
+  }
+}
+
+function renderEspLegend(model) {
+  if (!els.espLegendGradient || !els.espLegendTicks) return;
+  const rect = els.espLegendGradient.getBoundingClientRect();
+  const pixelRatio = Math.max(1, Number(window.devicePixelRatio) || 1);
+  const width = Math.max(1, Math.round(rect.width * pixelRatio));
+  const height = Math.max(1, Math.round(rect.height * pixelRatio));
+  if (els.espLegendGradient.width !== width) els.espLegendGradient.width = width;
+  if (els.espLegendGradient.height !== height) els.espLegendGradient.height = height;
+  const context = els.espLegendGradient.getContext('2d');
+  context.clearRect(0, 0, width, height);
+  paintEspLegendGradient(context, model, 0, 0, width, height);
+
+  const fragment = document.createDocumentFragment();
+  model.ticks.forEach((tick) => {
+    const label = document.createElement('span');
+    label.textContent = tick.label;
+    label.dataset.atomicUnits = String(tick.atomicUnits);
+    fragment.append(label);
+  });
+  els.espLegendTicks.replaceChildren(fragment);
+}
+
+function syncEspLegendMenuState() {
+  if (!els.guiToolEspLegend) return;
+  const available = Boolean(espLayerByKind('esp-density') && espLayerByKind('esp-potential'));
+  els.guiToolEspLegend.setAttribute('aria-checked', String(state.espAnalysis.legend.enabled));
+  els.guiToolEspLegend.setAttribute('aria-disabled', String(!available));
+  els.guiToolEspLegend.title = available ? '' : 'Generate an ESP surface before showing its legend';
+}
+
+function shouldDisplayEspLegend() {
+  return Boolean(
+    state.espAnalysis.legend.enabled
+    && isEspVisualizationActive()
+    && !isPlotPanelVisible()
+  );
+}
+
+function syncEspLegendVisibility() {
+  syncEspLegendMenuState();
+  if (!els.espLegend) return;
+  const model = currentEspLegendModel();
+  const visible = Boolean(model && shouldDisplayEspLegend());
+  els.espLegend.hidden = !visible;
+  if (!visible) {
+    finishEspLegendDrag();
+    return;
+  }
+  applyEspLegendPosition();
+  renderEspLegend(model);
+}
+
+function setEspLegendEnabled(enabled, options = {}) {
+  state.espAnalysis.legend.enabled = Boolean(enabled);
+  syncEspLegendVisibility();
+  if (options.announce !== false) {
+    setStatus(state.espAnalysis.legend.enabled ? 'ESP legend shown' : 'ESP legend hidden');
+  }
+}
+
+function clampedEspLegendPosition(left, top) {
+  const viewportRect = els.viewerWrap.getBoundingClientRect();
+  const legendRect = els.espLegend.getBoundingClientRect();
+  return {
+    left: clamp(Number(left) || 0, 0, Math.max(0, viewportRect.width - legendRect.width)),
+    top: clamp(Number(top) || 0, 0, Math.max(0, viewportRect.height - legendRect.height))
+  };
+}
+
+function applyEspLegendPosition() {
+  const position = state.espAnalysis.legend.position;
+  if (!position || els.espLegend.hidden) return;
+  const clamped = clampedEspLegendPosition(position.left, position.top);
+  state.espAnalysis.legend.position = clamped;
+  els.espLegend.style.left = `${clamped.left}px`;
+  els.espLegend.style.top = `${clamped.top}px`;
+}
+
+function finishEspLegendDrag(event = null) {
+  const legend = state.espAnalysis.legend;
+  const drag = legend.drag;
+  if (!drag) return;
+  if (drag.source === 'pointer' && event && event.pointerId !== drag.pointerId) return;
+  if (drag.source === 'pointer' && els.espLegendHeader?.hasPointerCapture?.(drag.pointerId)) {
+    els.espLegendHeader.releasePointerCapture(drag.pointerId);
+  }
+  legend.drag = null;
+  els.espLegend.classList.remove('is-dragging');
+}
+
+function beginEspLegendDrag(event, source) {
+  if (
+    state.espAnalysis.legend.drag
+    || event.button !== 0
+    || event.isPrimary === false
+    || event.target.closest('button')
+  ) return false;
+  const legendRect = els.espLegend.getBoundingClientRect();
+  const viewportRect = els.viewerWrap.getBoundingClientRect();
+  state.espAnalysis.legend.position = {
+    left: legendRect.left - viewportRect.left,
+    top: legendRect.top - viewportRect.top
+  };
+  state.espAnalysis.legend.drag = {
+    source,
+    pointerId: event.pointerId,
+    offsetX: event.clientX - legendRect.left,
+    offsetY: event.clientY - legendRect.top
+  };
+  els.espLegend.classList.add('is-dragging');
+  event.preventDefault();
+  return true;
+}
+
+function updateEspLegendDrag(clientX, clientY) {
+  const drag = state.espAnalysis.legend.drag;
+  if (!drag) return;
+  const viewportRect = els.viewerWrap.getBoundingClientRect();
+  state.espAnalysis.legend.position = clampedEspLegendPosition(
+    clientX - viewportRect.left - drag.offsetX,
+    clientY - viewportRect.top - drag.offsetY
+  );
+  applyEspLegendPosition();
+}
+
+function startEspLegendDrag(event) {
+  if (!beginEspLegendDrag(event, 'pointer')) return;
+  els.espLegendHeader.setPointerCapture?.(event.pointerId);
+}
+
+function moveEspLegend(event) {
+  const drag = state.espAnalysis.legend.drag;
+  if (!drag || drag.source !== 'pointer' || event.pointerId !== drag.pointerId) return;
+  updateEspLegendDrag(event.clientX, event.clientY);
+  event.preventDefault();
+}
+
+function startEspLegendMouseDrag(event) {
+  beginEspLegendDrag(event, 'mouse');
+}
+
+function moveEspLegendMouse(event) {
+  if (state.espAnalysis.legend.drag?.source !== 'mouse') return;
+  updateEspLegendDrag(event.clientX, event.clientY);
+  event.preventDefault();
+}
+
+function finishEspLegendMouseDrag() {
+  if (state.espAnalysis.legend.drag?.source === 'mouse') finishEspLegendDrag();
 }
 
 function currentEspExtremaPair() {
@@ -3921,6 +4131,7 @@ function refreshEspAnalysisCapabilities() {
   if (els.guiToolEsp) els.guiToolEsp.title = state.espAnalysis.capabilities.reason || '';
   syncEspExtremaMenuState();
   syncEspOpacityControls();
+  syncEspLegendVisibility();
 }
 
 async function loadManifestObject(manifest, baseUrl = '') {
@@ -4051,17 +4262,114 @@ function saveManifest() {
   downloadBlob('multiwfn-3dmol-manifest.json', 'application/json', `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
-function savePng() {
+function downloadPngDataUri(dataUri) {
+  const link = document.createElement('a');
+  link.href = dataUri;
+  link.download = 'multiwfn-3dmol-view.png';
+  document.body.append(link);
+  link.click();
+  link.remove();
+}
+
+function loadPngImage(dataUri) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image), { once: true });
+    image.addEventListener('error', () => reject(new Error('Could not decode the rendered PNG')), { once: true });
+    image.src = dataUri;
+  });
+}
+
+function roundedRectanglePath(context, x, y, width, height, radius) {
+  const corner = Math.max(0, Math.min(radius, width / 2, height / 2));
+  context.beginPath();
+  context.moveTo(x + corner, y);
+  context.lineTo(x + width - corner, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + corner);
+  context.lineTo(x + width, y + height - corner);
+  context.quadraticCurveTo(x + width, y + height, x + width - corner, y + height);
+  context.lineTo(x + corner, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - corner);
+  context.lineTo(x, y + corner);
+  context.quadraticCurveTo(x, y, x + corner, y);
+  context.closePath();
+}
+
+function drawEspLegendForExport(context, model, image) {
+  const viewportRect = els.viewerWrap.getBoundingClientRect();
+  const legendRect = els.espLegend.getBoundingClientRect();
+  const gradientRect = els.espLegendGradient.getBoundingClientRect();
+  if (!viewportRect.width || !viewportRect.height || !legendRect.width || !legendRect.height) return;
+
+  const scaleX = image.naturalWidth / viewportRect.width;
+  const scaleY = image.naturalHeight / viewportRect.height;
+  const scale = Math.min(scaleX, scaleY);
+  const projectRect = (rect) => ({
+    x: (rect.left - viewportRect.left) * scaleX,
+    y: (rect.top - viewportRect.top) * scaleY,
+    width: rect.width * scaleX,
+    height: rect.height * scaleY
+  });
+  const card = projectRect(legendRect);
+  const bar = projectRect(gradientRect);
+  const padding = (legendRect.width <= 160 ? 10 : 12) * scale;
+
+  context.save();
+  context.shadowColor = 'rgba(28, 36, 48, 0.14)';
+  context.shadowBlur = 12 * scale;
+  context.shadowOffsetY = 3 * scale;
+  roundedRectanglePath(context, card.x, card.y, card.width, card.height, 8 * scale);
+  context.fillStyle = 'rgba(247, 248, 250, 0.96)';
+  context.fill();
+  context.shadowColor = 'transparent';
+  context.strokeStyle = '#d7dde5';
+  context.lineWidth = Math.max(1, scale);
+  context.stroke();
+
+  const compact = legendRect.width <= 160;
+  context.fillStyle = '#1c2430';
+  context.font = `600 ${(compact ? 10 : 12) * scale}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  context.textBaseline = 'top';
+  context.fillText(els.espLegendTitle.textContent, card.x + padding, card.y + padding);
+  context.fillStyle = '#667085';
+  context.font = `400 ${(compact ? 10 : 11) * scale}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+  context.fillText(els.espLegendUnit.textContent, card.x + padding, card.y + padding + 17 * scale);
+
+  paintEspLegendGradient(context, model, bar.x, bar.y, bar.width, bar.height);
+  context.strokeStyle = '#c8d0dc';
+  context.lineWidth = Math.max(1, scale);
+  context.strokeRect(bar.x, bar.y, bar.width, bar.height);
+
+  context.fillStyle = '#1c2430';
+  context.font = `400 ${11 * scale}px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace`;
+  model.ticks.forEach((tick) => {
+    const y = bar.y + tick.fraction * bar.height;
+    context.textBaseline = tick.fraction === 0 ? 'top' : tick.fraction === 1 ? 'bottom' : 'middle';
+    context.fillText(tick.label, bar.x + bar.width + 10 * scale, y);
+  });
+  context.restore();
+}
+
+async function savePng() {
   try {
     const dataUri = typeof state.viewer.pngURI === 'function'
       ? state.viewer.pngURI()
       : els.viewer.querySelector('canvas').toDataURL('image/png');
-    const link = document.createElement('a');
-    link.href = dataUri;
-    link.download = 'multiwfn-3dmol-view.png';
-    document.body.append(link);
-    link.click();
-    link.remove();
+    const legendModel = currentEspLegendModel();
+    if (!legendModel || !shouldDisplayEspLegend() || els.espLegend.hidden) {
+      downloadPngDataUri(dataUri);
+      setStatus('PNG saved');
+      return;
+    }
+
+    const image = await loadPngImage(dataUri);
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const context = canvas.getContext('2d');
+    context.drawImage(image, 0, 0);
+    drawEspLegendForExport(context, legendModel, image);
+    downloadPngDataUri(canvas.toDataURL('image/png'));
     setStatus('PNG saved');
   } catch (error) {
     console.error(error);
@@ -4073,6 +4381,7 @@ function showPlotPanel(show = true) {
   els.plotPanel.classList.toggle('is-hidden', !show);
   updateOrientationVisibility();
   syncEspExtremaVisibility();
+  syncEspLegendVisibility();
   syncSceneOverlays();
 }
 
@@ -4822,6 +5131,14 @@ function bindEvents() {
       if (loaded && state.espAnalysis.extrema.enabled) void ensureEspExtremaForCurrentEsp();
     });
   });
+  els.guiToolEspLegend.addEventListener('click', () => {
+    setToolsMenuOpen(false);
+    if (els.guiToolEspLegend.getAttribute('aria-disabled') === 'true') {
+      setStatus('Generate an ESP surface before showing its legend', false);
+      return;
+    }
+    setEspLegendEnabled(!state.espAnalysis.legend.enabled);
+  });
   els.guiToolEspExtrema.addEventListener('click', () => {
     setToolsMenuOpen(false);
     const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
@@ -4834,6 +5151,17 @@ function bindEvents() {
   els.guiEspOpacity.addEventListener('input', () => {
     setEspSurfaceOpacity(Number(els.guiEspOpacity.value) / 100, { announce: true });
   });
+  els.espLegendClose.addEventListener('click', () => {
+    setEspLegendEnabled(false);
+  });
+  els.espLegendHeader.addEventListener('pointerdown', startEspLegendDrag);
+  els.espLegendHeader.addEventListener('pointermove', moveEspLegend);
+  els.espLegendHeader.addEventListener('pointerup', finishEspLegendDrag);
+  els.espLegendHeader.addEventListener('pointercancel', finishEspLegendDrag);
+  els.espLegendHeader.addEventListener('lostpointercapture', finishEspLegendDrag);
+  els.espLegendHeader.addEventListener('mousedown', startEspLegendMouseDrag);
+  document.addEventListener('mousemove', moveEspLegendMouse);
+  document.addEventListener('mouseup', finishEspLegendMouseDrag);
   document.addEventListener('click', (event) => {
     const toolsOpen = !els.guiToolsMenu.hidden || !els.guiEspMenu.hidden;
     if (toolsOpen && !els.guiToolsMenuControl.contains(event.target)) {
@@ -5232,9 +5560,17 @@ function cacheElements() {
     guiToolEsp: byId('gui-tool-esp'),
     guiEspMenu: byId('gui-esp-menu'),
     guiToolEspShow: byId('gui-tool-esp-show'),
+    guiToolEspLegend: byId('gui-tool-esp-legend'),
     guiToolEspExtrema: byId('gui-tool-esp-extrema'),
     guiEspOpacity: byId('gui-esp-opacity'),
     guiEspOpacityValue: byId('gui-esp-opacity-value'),
+    espLegend: byId('esp-legend'),
+    espLegendHeader: byId('esp-legend-header'),
+    espLegendTitle: byId('esp-legend-title'),
+    espLegendUnit: byId('esp-legend-unit'),
+    espLegendClose: byId('esp-legend-close'),
+    espLegendGradient: byId('esp-legend-gradient'),
+    espLegendTicks: byId('esp-legend-ticks'),
     modelLabel: byId('model-label'),
     cubeLabel: byId('cube-label'),
     structureFile: byId('structure-file'),
@@ -5371,4 +5707,5 @@ window.addEventListener('resize', () => {
   closeBondContextMenu();
   repositionOpenStyleSubmenu();
   repositionOpenEspToolsMenu();
+  syncEspLegendVisibility();
 });

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -206,7 +206,6 @@ const espExtremaMarkerRadii = {
   global: 0.24
 };
 const espExtremaMarkerVisualScale = 0.45;
-const espExtremaMarkerInsetScale = 2;
 const ESP_EXTREMA_WORKER_TIMEOUT = 60000;
 const bondPropertyDefinitions = [
   { id: 'length', label: 'Bond length', backend: false },
@@ -3075,34 +3074,29 @@ function handleEspExtremaMarkerClick(point, callbackArguments) {
   state.viewer.render();
 }
 
-function extremaStructureCenter() {
-  const atoms = state.atomSelection.atoms || [];
-  if (!atoms.length) return null;
-  const total = atoms.reduce((sum, atom) => ({
-    x: sum.x + Number(atom.x || 0),
-    y: sum.y + Number(atom.y || 0),
-    z: sum.z + Number(atom.z || 0)
-  }), { x: 0, y: 0, z: 0 });
-  return {
-    x: total.x / atoms.length,
-    y: total.y / atoms.length,
-    z: total.z / atoms.length
+function keepEspExtremaMarkerOpaque(shape) {
+  if (!shape || typeof shape.globj !== 'function') return shape;
+  const renderShape = shape.globj;
+  shape.globj = function renderOpaqueEspExtremaMarker(...args) {
+    const result = renderShape.apply(this, args);
+    const objects = [this.renderedShapeObj];
+    while (objects.length) {
+      const object = objects.pop();
+      if (!object) continue;
+      if (object.material) {
+        // 3Dmol rebuilds GLShape materials on every render. Keep markers in the
+        // transparent pass after the ESP surface without lowering their alpha.
+        object.material.transparent = true;
+        object.material.opacity = 1;
+        object.material.depthTest = true;
+        object.material.depthWrite = true;
+        object.material.needsUpdate = true;
+      }
+      if (Array.isArray(object.children)) objects.push(...object.children);
+    }
+    return result;
   };
-}
-
-function insetEspExtremaMarker(point, radius, structureCenter) {
-  if (!structureCenter) return { x: point.x, y: point.y, z: point.z };
-  const dx = structureCenter.x - point.x;
-  const dy = structureCenter.y - point.y;
-  const dz = structureCenter.z - point.z;
-  const length = Math.hypot(dx, dy, dz);
-  if (length < 1e-9) return { x: point.x, y: point.y, z: point.z };
-  const inset = radius * espExtremaMarkerInsetScale;
-  return {
-    x: point.x + dx * inset / length,
-    y: point.y + dy * inset / length,
-    z: point.z + dz * inset / length
-  };
+  return shape;
 }
 
 function renderEspExtremaMarkers(options = {}) {
@@ -3115,27 +3109,20 @@ function renderEspExtremaMarkers(options = {}) {
   }
 
   const points = espExtremaPoints();
-  const structureCenter = extremaStructureCenter();
   points.forEach((point) => {
     const radius = point.global ? espExtremaMarkerRadii.global : espExtremaMarkerRadii.local;
     const callback = (...args) => handleEspExtremaMarkerClick(point, args);
-    const visibleShape = state.viewer.addSphere({
-      center: insetEspExtremaMarker(point, radius, structureCenter),
+    const visibleShape = keepEspExtremaMarkerOpaque(state.viewer.addSphere({
+      center: { x: point.x, y: point.y, z: point.z },
       radius: radius * espExtremaMarkerVisualScale,
       color: espExtremaPointColor(point),
       opacity: 1,
       clickable: true,
       callback
-    });
-    const pickShape = state.viewer.addSphere({
-      center: { x: point.x, y: point.y, z: point.z },
-      radius,
-      color: espExtremaPointColor(point),
-      opacity: 0,
-      clickable: true,
-      callback
-    });
-    extrema.markerShapes.push(visibleShape, pickShape);
+    }));
+    const hitSphere = visibleShape?.intersectionShape?.sphere?.[0];
+    if (hitSphere) hitSphere.radius = radius;
+    extrema.markerShapes.push(visibleShape);
   });
   const selected = points.find((point) => point.id === extrema.selectedPointId);
   if (selected) showEspExtremaLabel(selected);

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -186,6 +186,8 @@ const atomicSymbols = {
 };
 
 const cubeCoordinates = window.MultiwfnCubeCoordinates;
+const espScale = window.MultiwfnEspScale;
+const espExtrema = window.MultiwfnEspExtrema;
 
 const orbitalPhaseColors = {
   positive: '#f5a9b8',
@@ -194,6 +196,18 @@ const orbitalPhaseColors = {
 
 const atomSelectionColor = '#ffd400';
 const atomClickSphereRadius = 0.45;
+const espSurfaceColors = {
+  negative: '#f5a9b8',
+  zero: '#ffffff',
+  positive: '#5bcefa'
+};
+const espExtremaMarkerRadii = {
+  local: 0.18,
+  global: 0.24
+};
+const espExtremaMarkerVisualScale = 0.45;
+const espExtremaMarkerInsetScale = 2;
+const ESP_EXTREMA_WORKER_TIMEOUT = 60000;
 const bondPropertyDefinitions = [
   { id: 'length', label: 'Bond length', backend: false },
   { id: 'display_order', label: 'Displayed bond order', backend: false },
@@ -217,12 +231,21 @@ function defaultBondAnalysisCapabilities() {
   };
 }
 
+function defaultEspAnalysisCapabilities() {
+  return {
+    available: false,
+    periodicSupported: false,
+    defaultIsovalue: 0.001,
+    reason: 'Multiwfn ESP backend is unavailable for this session'
+  };
+}
+
 const roleDefaults = {
   homo: { label: 'HOMO', ...orbitalPhaseColors, isovalue: 0.015 },
   lumo: { label: 'LUMO', ...orbitalPhaseColors, isovalue: 0.015 },
   density: { label: 'Density', positive: '#7c5ac9', negative: '#7c5ac9', isovalue: 0.02 },
   elf: { label: 'ELF', positive: '#d4a21b', negative: '#d4a21b', isovalue: 0.65 },
-  esp: { label: 'ESP', positive: '#2b73c8', negative: '#cf3f55', isovalue: 0.02 },
+  esp: { label: 'ESP', positive: espSurfaceColors.positive, negative: espSurfaceColors.negative, isovalue: 0.02 },
   custom: { label: 'Custom', ...orbitalPhaseColors, isovalue: 0.015 }
 };
 
@@ -240,6 +263,20 @@ const backgrounds = {
 };
 
 const gradients = {
+  trans: {
+    label: 'Trans flag',
+    make: (min, max) => ({
+      gradient: 'multiwfn-trans',
+      min,
+      max,
+      range: () => [min, max],
+      valueToHex: (value, range) => espScale.transFlagColorHex(
+        value,
+        range?.[0] ?? min,
+        range?.[1] ?? max
+      )
+    })
+  },
   rwb: { label: 'RWB', make: (min, max) => new $3Dmol.Gradient.RWB(min, max) },
   roygb: { label: 'ROYGB', make: (min, max) => new $3Dmol.Gradient.ROYGB(min, max) },
   sinebow: { label: 'Sinebow', make: (min, max) => new $3Dmol.Gradient.Sinebow(min, max) }
@@ -291,6 +328,7 @@ const state = {
     manifestOrbitalLoads: new Map()
   },
   orbitalShapes: new Map(),
+  surfaceShapes: new Map(),
   atomSelection: {
     indices: new Set(),
     model: null,
@@ -312,6 +350,32 @@ const state = {
       clickedAtomIndex: null,
       bonds: [],
       activeBondKey: ''
+    }
+  },
+  espAnalysis: {
+    capabilities: defaultEspAnalysisCapabilities(),
+    baseCapabilities: defaultEspAnalysisCapabilities(),
+    requestBusy: false,
+    densityLayerId: '',
+    potentialLayerId: '',
+    quality: 0,
+    isovalue: 0.001,
+    opacity: 0.88,
+    opacityFrame: 0,
+    extrema: {
+      enabled: false,
+      busy: false,
+      sessionGeneration: 0,
+      requestGeneration: 0,
+      worker: null,
+      workerTimeout: 0,
+      workerReject: null,
+      cache: new Map(),
+      result: null,
+      resultKey: '',
+      markerShapes: [],
+      label: null,
+      selectedPointId: ''
     }
   },
   activePlot: null,
@@ -506,7 +570,9 @@ function syncPeriodicFromControls() {
   if (previousStructureKey !== nextStructureKey) {
     clearAtomSelectionState();
     clearBondAnalysisState();
+    resetEspExtremaState({ render: false });
     refreshBondAnalysisCapabilities();
+    refreshEspAnalysisCapabilities();
   }
 }
 
@@ -648,9 +714,13 @@ function isOrbitalLayer(layer) {
   return ['orbital', 'homo', 'lumo'].includes(layer.role) || Number(layer.orbitalIndex) > 0;
 }
 
-function registerOrbitalShape(layer, shape) {
-  if (!isOrbitalLayer(layer) || !shape) return shape;
+function registerSurfaceShape(layer, shape) {
+  if (!shape) return shape;
   const layerId = String(layer.id);
+  const surfaceShapes = state.surfaceShapes.get(layerId) || [];
+  surfaceShapes.push(shape);
+  state.surfaceShapes.set(layerId, surfaceShapes);
+  if (!isOrbitalLayer(layer)) return shape;
   const shapes = state.orbitalShapes.get(layerId) || [];
   shapes.push(shape);
   state.orbitalShapes.set(layerId, shapes);
@@ -1026,12 +1096,28 @@ function atomSelectionSpec(indices) {
   return { index: values.length === 1 ? values[0] : values };
 }
 
-function enableAtomContextSelection(model, selection = {}) {
+function atomSelectionPlatform() {
+  if (typeof navigator === 'undefined') return '';
+  return String(navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || '');
+}
+
+function atomSelectionModifierPressed(event, platform = atomSelectionPlatform()) {
+  if (!event) return false;
+  return /mac|iphone|ipad|ipod/i.test(platform)
+    ? event.metaKey === true
+    : event.ctrlKey === true;
+}
+
+function isPrimaryAtomClick(event) {
+  return Boolean(event) && (event.button === undefined || Number(event.button) === 0);
+}
+
+function enableAtomInteractions(model, selection = {}) {
   if (!model) return;
   if (typeof model.setStyle === 'function') {
     model.setStyle(selection, { clicksphere: { radius: atomClickSphereRadius } }, true);
   }
-  if (typeof model.setClickable === 'function') model.setClickable(selection, true, () => {});
+  if (typeof model.setClickable === 'function') model.setClickable(selection, true, handleAtomClick);
   if (typeof model.enableContextMenu === 'function') model.enableContextMenu(selection, true);
 }
 
@@ -1042,7 +1128,7 @@ function applyAtomSelectionStyle(model, indices, selected) {
   if (!model || !values.length || typeof model.setStyle !== 'function') return;
   const selection = atomSelectionSpec(values);
   model.setStyle(selection, selected ? selectedAtomModelStyle() : modelStyle());
-  enableAtomContextSelection(model, selection);
+  enableAtomInteractions(model, selection);
 }
 
 function renderAtomSelectionDecorations(model = state.atomSelection.model, options = {}) {
@@ -1066,7 +1152,7 @@ function updateStructureAppearance() {
   const model = state.atomSelection.model;
   if (!state.viewer || !model || typeof model.setStyle !== 'function') return;
   model.setStyle({}, modelStyle());
-  enableAtomContextSelection(model);
+  enableAtomInteractions(model);
   const selectedIndices = [...state.atomSelection.indices];
   if (selectedIndices.length) applyAtomSelectionStyle(model, selectedIndices, true);
   if (els.showStructure.checked) model.show();
@@ -1548,7 +1634,10 @@ function renderBondPropertyMenu(menu, bond) {
     const button = createBondMenuButton(property.label, {
       value,
       disabled: property.backend && (
-        !capability.available || state.bondAnalysis.requestBusy || state.gui.orbitalRequestBusy
+        !capability.available
+        || state.bondAnalysis.requestBusy
+        || state.gui.orbitalRequestBusy
+        || state.espAnalysis.requestBusy
       ),
       reason: property.backend && !capability.available ? capability.reason : '',
       title: detail || capability.reason || '',
@@ -1574,15 +1663,28 @@ function openBondPropertySubmenu(trigger, bond) {
   requestAnimationFrame(() => bondMenuButtons(els.bondContextSubmenu)[0]?.focus());
 }
 
-function deselectAtomIndex(atomIndex) {
-  if (!state.atomSelection.indices.has(atomIndex)) return;
-  const atomName = atomDisplayName(atomMapForModel().get(atomIndex), atomIndex);
-  state.atomSelection.indices.delete(atomIndex);
-  applyAtomSelectionStyle(state.atomSelection.model, atomIndex, false);
+function setAtomSelected(atomIndex, selected, atom = atomMapForModel().get(atomIndex)) {
+  const isSelected = state.atomSelection.indices.has(atomIndex);
+  if (isSelected === selected) return false;
+  if (selected) state.atomSelection.indices.add(atomIndex);
+  else state.atomSelection.indices.delete(atomIndex);
+  applyAtomSelectionStyle(state.atomSelection.model, atomIndex, selected);
   syncAtomLabels({ indices: atomIndex, forceStyles: true, render: false });
   state.viewer.render();
   syncSceneOverlays();
-  setStatus(`Deselected atom ${atomName} (${state.atomSelection.indices.size} selected)`);
+  const action = selected ? 'Selected' : 'Deselected';
+  setStatus(`${action} atom ${atomDisplayName(atom, atomIndex)} (${state.atomSelection.indices.size} selected)`);
+  return true;
+}
+
+function toggleAtomSelection(selected) {
+  if (!selected || !Number.isFinite(Number(selected.index))) return false;
+  const atomIndex = Number(selected.index);
+  return setAtomSelected(atomIndex, !state.atomSelection.indices.has(atomIndex), selected);
+}
+
+function deselectAtomIndex(atomIndex) {
+  return setAtomSelected(atomIndex, false);
 }
 
 function clearSelectedAtoms() {
@@ -1604,7 +1706,7 @@ function openBondContextMenu(selected, x, y, bonds) {
 
   if (bonds.length === 1) {
     renderBondPropertyMenu(els.bondContextMenu, bonds[0]);
-  } else {
+  } else if (bonds.length > 1) {
     appendBondMenuHeading(els.bondContextMenu, 'Selected bonds');
     bonds.forEach((bond) => {
       const trigger = createBondMenuButton(bond.label, {
@@ -1618,7 +1720,7 @@ function openBondContextMenu(selected, x, y, bonds) {
     });
   }
 
-  appendBondMenuSeparator(els.bondContextMenu);
+  if (bonds.length) appendBondMenuSeparator(els.bondContextMenu);
   const clickedName = atomDisplayName(selected, Number(selected.index));
   els.bondContextMenu.append(createBondMenuButton(`Deselect ${clickedName}`, {
     onClick: () => {
@@ -1655,7 +1757,11 @@ function cacheRelatedOpenShellResults(bond, payload) {
 }
 
 function syncBackendRequestControls() {
-  const busy = Boolean(state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy);
+  const busy = Boolean(
+    state.gui.orbitalRequestBusy
+    || state.bondAnalysis.requestBusy
+    || state.espAnalysis.requestBusy
+  );
   [
     els.guiOrbitalSelect,
     els.guiOrbitalInput,
@@ -1663,7 +1769,9 @@ function syncBackendRequestControls() {
     els.guiOrbitalIsovalueNumber,
     els.guiOrbPrev,
     els.guiOrbNext,
-    els.guiMenuQuality
+    els.guiMenuQuality,
+    els.guiToolEspShow,
+    els.guiToolEspExtrema
   ].forEach((control) => {
     if (control) control.disabled = busy;
   });
@@ -1694,7 +1802,7 @@ async function selectBondProperty(bond, method) {
     setStatus(`${bondPropertyDefinition(method).label} loaded from cache`);
     return;
   }
-  if (state.bondAnalysis.requestBusy || state.gui.orbitalRequestBusy) {
+  if (state.bondAnalysis.requestBusy || state.gui.orbitalRequestBusy || state.espAnalysis.requestBusy) {
     setStatus('Multiwfn backend is busy', false);
     return;
   }
@@ -1740,32 +1848,20 @@ async function selectBondProperty(bond, method) {
   }
 }
 
-function handleAtomContextMenu(selected, x = 0, y = 0) {
-  if (!selected || !Number.isFinite(Number(selected.index))) {
-    closeBondContextMenu();
-    clearSelectedAtoms();
-    return;
-  }
+function handleAtomClick(selected, _viewer, event) {
+  if (!isPrimaryAtomClick(event) || !atomSelectionModifierPressed(event)) return;
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  closeBondContextMenu();
+  toggleAtomSelection(selected);
+}
 
+function handleAtomContextMenu(selected, x = 0, y = 0) {
+  closeBondContextMenu();
+  if (!selected || !Number.isFinite(Number(selected.index))) return;
   const atomIndex = Number(selected.index);
-  const wasSelected = state.atomSelection.indices.has(atomIndex);
-  if (wasSelected) {
-    const bonds = selectedAdjacentBonds();
-    if (bonds.length) {
-      openBondContextMenu(selected, x, y, bonds);
-      return;
-    }
-    state.atomSelection.indices.delete(atomIndex);
-  } else {
-    closeBondContextMenu();
-    state.atomSelection.indices.add(atomIndex);
-  }
-  applyAtomSelectionStyle(state.atomSelection.model, atomIndex, !wasSelected);
-  syncAtomLabels({ indices: atomIndex, forceStyles: true, render: false });
-  state.viewer.render();
-  syncSceneOverlays();
-  const action = wasSelected ? 'Deselected' : 'Selected';
-  setStatus(`${action} atom ${atomDisplayName(selected, atomIndex)} (${state.atomSelection.indices.size} selected)`);
+  if (!state.atomSelection.indices.has(atomIndex)) return;
+  openBondContextMenu(selected, x, y, selectedAdjacentBonds());
 }
 
 function applyDisplayedBondOrders(model, data, format) {
@@ -1850,7 +1946,7 @@ function addStructureToViewer() {
     const model = state.viewer.addModel(display.data, display.format);
     applyDisplayedBondOrders(model, display.data, display.format);
     model.setStyle({}, modelStyle());
-    enableAtomContextSelection(model);
+    enableAtomInteractions(model);
     if (!els.showStructure.checked) model.hide();
     return model;
   } catch (error) {
@@ -1996,7 +2092,7 @@ function addCubeLayer(layer) {
         if (!startupMetrics.ready) {
           startupMetrics.initialIsosurfaceCalls = (startupMetrics.initialIsosurfaceCalls || 0) + 1;
         }
-        return registerOrbitalShape(layer, state.viewer.addIsosurface(volume, spec));
+        return registerSurfaceShape(layer, state.viewer.addIsosurface(volume, spec));
       };
       if (surfaceStyle === 'mesh' || surfaceStyle === 'points') {
         addIsosurface({
@@ -2032,13 +2128,16 @@ function renderScene(zoom = false) {
   if (!startupMetrics.ready) startupMetrics.initialSceneRenders = (startupMetrics.initialSceneRenders || 0) + 1;
 
   state.orbitalShapes.clear();
+  state.surfaceShapes.clear();
   resetAtomDecorationReferences();
+  resetEspExtremaDecorationReferences();
   state.viewer.clear();
   applySceneStyle();
   const structureModel = addStructureToViewer();
   state.layers.filter((layer) => layer.visible).forEach(addCubeLayer);
   drawCellBox();
   renderAtomSelectionDecorations(structureModel);
+  renderEspExtremaMarkers({ render: false });
 
   if (zoom || state.dirtyZoom) {
     state.viewer.zoomTo();
@@ -2467,6 +2566,68 @@ function setGlobalOrbitalOpacity(value, options = {}) {
   if (options.announce) setStatus(`Orbital opacity: ${orbitalOpacityPercent(opacity)}%`);
 }
 
+function espOpacityPercent(opacity = state.espAnalysis.opacity) {
+  return Math.round(clamp(toNumber(opacity, 0.88), 0.05, 1) * 100);
+}
+
+function syncEspOpacityControls() {
+  const opacity = clamp(toNumber(state.espAnalysis.opacity, 0.88), 0.05, 1);
+  const percent = espOpacityPercent(opacity);
+  if (els.guiEspOpacity) {
+    els.guiEspOpacity.value = String(percent);
+    els.guiEspOpacity.setAttribute('aria-valuetext', `${percent}%`);
+  }
+  if (els.guiEspOpacityValue) els.guiEspOpacityValue.textContent = `${percent}%`;
+
+  const density = espLayerByKind('esp-density');
+  if (density) density.opacity = opacity;
+  const rowControl = density
+    ? document.querySelector(`.layer-row[data-layer-id="${density.id}"] [data-action="opacity"]`)
+    : null;
+  if (rowControl) rowControl.value = String(opacity);
+  if (density && String(state.gui.activeLayerId) === String(density.id) && els.guiIsosurfaceOpacity) {
+    els.guiIsosurfaceOpacity.value = String(opacity);
+  }
+}
+
+function updateEspSurfaceOpacity(opacity) {
+  const density = espLayerByKind('esp-density');
+  if (!state.viewer || !density) return;
+  const shapes = state.surfaceShapes.get(String(density.id)) || [];
+  let updated = 0;
+  shapes.forEach((shape) => {
+    if (!shape || typeof shape.updateStyle !== 'function') return;
+    try {
+      const style = { opacity };
+      if (shape.stylespec?.voldata && shape.stylespec?.volscheme) {
+        style.voldata = shape.stylespec.voldata;
+        style.volscheme = shape.stylespec.volscheme;
+      }
+      shape.updateStyle(style);
+      updated += 1;
+    } catch (error) {
+      console.error(error);
+    }
+  });
+  if (updated) state.viewer.render();
+}
+
+function scheduleEspSurfaceOpacityUpdate() {
+  if (state.espAnalysis.opacityFrame) return;
+  state.espAnalysis.opacityFrame = requestAnimationFrame(() => {
+    state.espAnalysis.opacityFrame = 0;
+    updateEspSurfaceOpacity(state.espAnalysis.opacity);
+  });
+}
+
+function setEspSurfaceOpacity(value, options = {}) {
+  const opacity = clamp(toNumber(value, state.espAnalysis.opacity), 0.05, 1);
+  state.espAnalysis.opacity = opacity;
+  syncEspOpacityControls();
+  if (options.updateShapes !== false) scheduleEspSurfaceOpacityUpdate();
+  if (options.announce) setStatus(`ESP surface opacity: ${espOpacityPercent(opacity)}%`);
+}
+
 function syncBackgroundStyleControls() {
   const background = els.background?.value || 'white';
   if (els.guiBackgroundWhite) els.guiBackgroundWhite.setAttribute('aria-checked', String(background === 'white'));
@@ -2554,13 +2715,106 @@ function setStyleMenuOpen(open, options = {}) {
   }
 }
 
+function toolsMenuButtons() {
+  return [...els.guiToolsMenu.querySelectorAll('[role="menuitem"], [role="menuitemcheckbox"]')];
+}
+
+function espToolsMenuControls() {
+  return [els.guiToolEspShow, els.guiToolEspExtrema, els.guiEspOpacity].filter(Boolean);
+}
+
+function closeEspToolsMenu(options = {}) {
+  if (!els.guiEspMenu) return;
+  els.guiEspMenu.hidden = true;
+  els.guiToolEsp.setAttribute('aria-expanded', 'false');
+  if (options.focus) els.guiToolEsp.focus();
+}
+
+function setEspToolsMenuOpen(open, options = {}) {
+  if (!els.guiEspMenu) return;
+  const isOpen = Boolean(open);
+  els.guiEspMenu.hidden = !isOpen;
+  els.guiToolEsp.setAttribute('aria-expanded', String(isOpen));
+  if (!isOpen) return;
+  syncEspOpacityControls();
+  positionStyleSubmenu(els.guiToolEsp, els.guiEspMenu);
+  if (options.focus) requestAnimationFrame(() => espToolsMenuControls()[0]?.focus());
+}
+
+function repositionOpenEspToolsMenu() {
+  if (els.guiEspMenu && !els.guiEspMenu.hidden) {
+    positionStyleSubmenu(els.guiToolEsp, els.guiEspMenu);
+  }
+}
+
+function setToolsMenuOpen(open, options = {}) {
+  const isOpen = Boolean(open);
+  if (!isOpen) closeEspToolsMenu();
+  els.guiToolsMenu.hidden = !isOpen;
+  els.guiMenuTools.setAttribute('aria-expanded', String(isOpen));
+  if (isOpen && options.focus) requestAnimationFrame(() => toolsMenuButtons()[0]?.focus());
+}
+
+function handleToolsMenuKeydown(event) {
+  const buttons = toolsMenuButtons();
+  const current = buttons.indexOf(document.activeElement);
+  if (event.key === 'ArrowRight' && document.activeElement === els.guiToolEsp) {
+    setEspToolsMenuOpen(true, { focus: true });
+    event.preventDefault();
+    return;
+  }
+  if (event.key === 'Escape') {
+    setToolsMenuOpen(false);
+    els.guiMenuTools.focus();
+    event.preventDefault();
+    return;
+  }
+  let target = -1;
+  if (event.key === 'ArrowDown') target = current < 0 ? 0 : (current + 1) % buttons.length;
+  if (event.key === 'ArrowUp') target = current < 0 ? buttons.length - 1 : (current - 1 + buttons.length) % buttons.length;
+  if (event.key === 'Home') target = 0;
+  if (event.key === 'End') target = buttons.length - 1;
+  if (target >= 0) {
+    buttons[target]?.focus();
+    event.preventDefault();
+  }
+}
+
+function handleEspToolsMenuKeydown(event) {
+  const controls = espToolsMenuControls();
+  const current = controls.indexOf(document.activeElement);
+  if (document.activeElement === els.guiEspOpacity) {
+    if (event.key === 'Escape') {
+      closeEspToolsMenu({ focus: true });
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    return;
+  }
+  if (event.key === 'Escape' || event.key === 'ArrowLeft') {
+    closeEspToolsMenu({ focus: true });
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+  let target = -1;
+  if (event.key === 'ArrowDown') target = current < 0 ? 0 : (current + 1) % controls.length;
+  if (event.key === 'ArrowUp') target = current < 0 ? controls.length - 1 : (current - 1 + controls.length) % controls.length;
+  if (event.key === 'Home') target = 0;
+  if (event.key === 'End') target = controls.length - 1;
+  if (target >= 0) {
+    controls[target]?.focus();
+    event.preventDefault();
+  }
+}
+
 function setGuiOrbitalRequestBusy(busy) {
   state.gui.orbitalRequestBusy = Boolean(busy);
   syncBackendRequestControls();
 }
 
 async function requestGuiOrbital(index, options = {}) {
-  if (state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy) return;
+  if (state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy || state.espAnalysis.requestBusy) return;
   const orbitalIndex = Number(index) || 0;
   els.guiOrbitalInput.value = String(orbitalIndex);
   if (orbitalIndex <= 0) {
@@ -2664,6 +2918,589 @@ async function requestGuiOrbital(index, options = {}) {
   }
 }
 
+function espLayerByKind(kind) {
+  return state.layers.find((layer) => layer.analysisKind === kind) || null;
+}
+
+function isEspVisualizationActive() {
+  const density = espLayerByKind('esp-density');
+  return Boolean(density?.visible && String(state.gui.activeLayerId) === String(density.id));
+}
+
+function espExtremaPoints(result = state.espAnalysis.extrema.result) {
+  return result ? [...(result.minima || []), ...(result.maxima || [])] : [];
+}
+
+function isPlotPanelVisible() {
+  return Boolean(els.plotPanel && !els.plotPanel.classList.contains('is-hidden'));
+}
+
+function currentEspExtremaPair() {
+  const density = espLayerByKind('esp-density');
+  const potential = espLayerByKind('esp-potential');
+  return density?.data && potential?.data ? { density, potential } : null;
+}
+
+function currentEspExtremaKey(pair = currentEspExtremaPair()) {
+  if (!pair) return '';
+  const quality = Number(pair.density.gridQuality || state.espAnalysis.quality || 0);
+  const isovalue = Number(pair.density.isovalue || state.espAnalysis.isovalue || 0.001);
+  return espExtrema?.extremaCacheKey(
+    state.espAnalysis.extrema.sessionGeneration,
+    quality,
+    isovalue
+  ) || `${state.espAnalysis.extrema.sessionGeneration}:${quality}:${isovalue}`;
+}
+
+function syncEspExtremaMenuState() {
+  if (!els.guiToolEspExtrema) return;
+  const extrema = state.espAnalysis.extrema;
+  const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
+  els.guiToolEspExtrema.setAttribute('aria-checked', String(extrema.enabled));
+  els.guiToolEspExtrema.setAttribute('aria-disabled', String(!capability.available));
+  els.guiToolEspExtrema.setAttribute('aria-busy', String(extrema.busy));
+  els.guiToolEspExtrema.title = capability.available ? '' : capability.reason;
+}
+
+function removeEspExtremaLabel() {
+  const extrema = state.espAnalysis.extrema;
+  if (extrema.label && state.viewer && typeof state.viewer.removeLabel === 'function') {
+    withSuppressedViewerShow(() => state.viewer.removeLabel(extrema.label));
+  }
+  extrema.label = null;
+}
+
+function resetEspExtremaDecorationReferences() {
+  const extrema = state.espAnalysis.extrema;
+  extrema.markerShapes = [];
+  extrema.label = null;
+}
+
+function clearEspExtremaMarkers(options = {}) {
+  const extrema = state.espAnalysis.extrema;
+  removeEspExtremaLabel();
+  if (state.viewer && typeof state.viewer.removeShape === 'function') {
+    extrema.markerShapes.forEach((shape) => {
+      try {
+        state.viewer.removeShape(shape);
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  }
+  extrema.markerShapes = [];
+  if (options.clearSelection) extrema.selectedPointId = '';
+  if (options.render !== false && state.viewer) state.viewer.render();
+}
+
+function shouldDisplayEspExtrema() {
+  const extrema = state.espAnalysis.extrema;
+  return Boolean(
+    extrema.enabled
+    && extrema.result
+    && extrema.resultKey === currentEspExtremaKey()
+    && isEspVisualizationActive()
+    && !isPlotPanelVisible()
+  );
+}
+
+function espExtremaPointColor(point) {
+  const value = Number(point?.value || 0);
+  if (Math.abs(value) <= 1e-12) return espSurfaceColors.zero;
+  return value < 0 ? espSurfaceColors.negative : espSurfaceColors.positive;
+}
+
+function formatEspExtremaPoint(point) {
+  const type = point.type === 'minimum' ? 'min' : 'max';
+  const name = point.global
+    ? `Global ${type}`
+    : `${type[0].toUpperCase()}${type.slice(1)} ${point.rank}`;
+  const value = Number(point.value);
+  const signedValue = `${value >= 0 ? '+' : ''}${value.toFixed(6)}`;
+  return `${name}  ${signedValue} a.u.  (${Number(point.kcalMol).toFixed(2)} kcal/mol)`;
+}
+
+function configureEspExtremaLabelLayer(label) {
+  if (!label?.sprite) return;
+  label.sprite.renderOrder = 300;
+  if (label.sprite.material) {
+    label.sprite.material.depthTest = false;
+    label.sprite.material.depthWrite = false;
+    label.sprite.material.needsUpdate = true;
+  }
+  const modelGroup = state.viewer?.modelGroup;
+  if (modelGroup && typeof modelGroup.remove === 'function' && typeof modelGroup.add === 'function') {
+    modelGroup.remove(label.sprite);
+    modelGroup.add(label.sprite);
+  }
+}
+
+function showEspExtremaLabel(point) {
+  const extrema = state.espAnalysis.extrema;
+  removeEspExtremaLabel();
+  if (!point || !state.viewer) return;
+  const text = formatEspExtremaPoint(point);
+  extrema.label = state.viewer.addLabel(text, {
+    position: { x: point.x, y: point.y, z: point.z },
+    fontSize: 12,
+    fontColor: '#111820',
+    backgroundColor: espExtremaPointColor(point),
+    backgroundOpacity: 0.96,
+    borderThickness: 1,
+    borderColor: '#111820',
+    inFront: true
+  }, undefined, true);
+  configureEspExtremaLabelLayer(extrema.label);
+  setStatus(text);
+}
+
+function handleEspExtremaMarkerClick(point, callbackArguments) {
+  const event = callbackArguments.find((argument) => (
+    argument && typeof argument === 'object'
+    && ('metaKey' in argument || 'ctrlKey' in argument || 'button' in argument)
+  ));
+  if (event?.metaKey || event?.ctrlKey || (event?.button !== undefined && Number(event.button) !== 0)) return;
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  const extrema = state.espAnalysis.extrema;
+  if (extrema.selectedPointId === point.id) {
+    extrema.selectedPointId = '';
+    removeEspExtremaLabel();
+    state.viewer.render();
+    setStatus('ESP extrema label hidden');
+    return;
+  }
+  extrema.selectedPointId = point.id;
+  showEspExtremaLabel(point);
+  state.viewer.render();
+}
+
+function extremaStructureCenter() {
+  const atoms = state.atomSelection.atoms || [];
+  if (!atoms.length) return null;
+  const total = atoms.reduce((sum, atom) => ({
+    x: sum.x + Number(atom.x || 0),
+    y: sum.y + Number(atom.y || 0),
+    z: sum.z + Number(atom.z || 0)
+  }), { x: 0, y: 0, z: 0 });
+  return {
+    x: total.x / atoms.length,
+    y: total.y / atoms.length,
+    z: total.z / atoms.length
+  };
+}
+
+function insetEspExtremaMarker(point, radius, structureCenter) {
+  if (!structureCenter) return { x: point.x, y: point.y, z: point.z };
+  const dx = structureCenter.x - point.x;
+  const dy = structureCenter.y - point.y;
+  const dz = structureCenter.z - point.z;
+  const length = Math.hypot(dx, dy, dz);
+  if (length < 1e-9) return { x: point.x, y: point.y, z: point.z };
+  const inset = radius * espExtremaMarkerInsetScale;
+  return {
+    x: point.x + dx * inset / length,
+    y: point.y + dy * inset / length,
+    z: point.z + dz * inset / length
+  };
+}
+
+function renderEspExtremaMarkers(options = {}) {
+  const extrema = state.espAnalysis.extrema;
+  clearEspExtremaMarkers({ render: false });
+  if (!shouldDisplayEspExtrema() || !state.viewer) {
+    extrema.selectedPointId = '';
+    if (options.render !== false && state.viewer) state.viewer.render();
+    return;
+  }
+
+  const points = espExtremaPoints();
+  const structureCenter = extremaStructureCenter();
+  points.forEach((point) => {
+    const radius = point.global ? espExtremaMarkerRadii.global : espExtremaMarkerRadii.local;
+    const callback = (...args) => handleEspExtremaMarkerClick(point, args);
+    const visibleShape = state.viewer.addSphere({
+      center: insetEspExtremaMarker(point, radius, structureCenter),
+      radius: radius * espExtremaMarkerVisualScale,
+      color: espExtremaPointColor(point),
+      opacity: 1,
+      clickable: true,
+      callback
+    });
+    const pickShape = state.viewer.addSphere({
+      center: { x: point.x, y: point.y, z: point.z },
+      radius,
+      color: espExtremaPointColor(point),
+      opacity: 0,
+      clickable: true,
+      callback
+    });
+    extrema.markerShapes.push(visibleShape, pickShape);
+  });
+  const selected = points.find((point) => point.id === extrema.selectedPointId);
+  if (selected) showEspExtremaLabel(selected);
+  else extrema.selectedPointId = '';
+  if (options.render !== false) state.viewer.render();
+}
+
+function syncEspExtremaVisibility(options = {}) {
+  renderEspExtremaMarkers(options);
+  syncEspExtremaMenuState();
+}
+
+function disposeEspExtremaWorker(reason = '') {
+  const extrema = state.espAnalysis.extrema;
+  const reject = extrema.workerReject;
+  extrema.workerReject = null;
+  if (extrema.workerTimeout) window.clearTimeout(extrema.workerTimeout);
+  extrema.workerTimeout = 0;
+  if (extrema.worker) extrema.worker.terminate();
+  extrema.worker = null;
+  if (reason && reject) {
+    const error = new Error(reason);
+    error.name = 'AbortError';
+    reject(error);
+  }
+}
+
+function resetEspExtremaState(options = {}) {
+  const extrema = state.espAnalysis.extrema;
+  extrema.requestGeneration += 1;
+  disposeEspExtremaWorker('ESP extrema analysis cancelled');
+  extrema.enabled = false;
+  extrema.busy = false;
+  extrema.result = null;
+  extrema.resultKey = '';
+  extrema.selectedPointId = '';
+  if (options.clearCache !== false) {
+    extrema.cache.clear();
+    extrema.sessionGeneration += 1;
+  }
+  clearEspExtremaMarkers({ render: options.render, clearSelection: true });
+  syncEspExtremaMenuState();
+}
+
+function invalidateEspExtremaCubeData() {
+  const extrema = state.espAnalysis.extrema;
+  extrema.requestGeneration += 1;
+  disposeEspExtremaWorker('ESP cube data changed');
+  extrema.busy = false;
+  extrema.result = null;
+  extrema.resultKey = '';
+  extrema.selectedPointId = '';
+  extrema.cache.clear();
+  clearEspExtremaMarkers({ render: false, clearSelection: true });
+  syncEspExtremaMenuState();
+}
+
+function runEspExtremaWorker(pair, isovalue) {
+  const extrema = state.espAnalysis.extrema;
+  if (typeof Worker !== 'function') return Promise.reject(new Error('Web Worker is unavailable'));
+  disposeEspExtremaWorker('ESP extrema analysis superseded');
+  const requestId = ++extrema.requestGeneration;
+  const workerUrl = new URL('esp-extrema-worker.js', window.location.href);
+  const worker = new Worker(workerUrl, { name: 'multiwfn-esp-extrema' });
+  extrema.worker = worker;
+
+  return new Promise((resolve, reject) => {
+    const finish = () => {
+      if (extrema.workerTimeout) window.clearTimeout(extrema.workerTimeout);
+      extrema.workerTimeout = 0;
+      if (extrema.worker === worker) extrema.worker = null;
+      if (extrema.workerReject === reject) extrema.workerReject = null;
+      worker.terminate();
+    };
+    extrema.workerReject = reject;
+    extrema.workerTimeout = window.setTimeout(() => {
+      finish();
+      reject(new Error('Timed out locating ESP extrema'));
+    }, ESP_EXTREMA_WORKER_TIMEOUT);
+    worker.addEventListener('message', (event) => {
+      const payload = event.data || {};
+      if (payload.requestId !== requestId || requestId !== extrema.requestGeneration) {
+        finish();
+        const error = new Error('ESP extrema analysis superseded');
+        error.name = 'AbortError';
+        reject(error);
+        return;
+      }
+      finish();
+      if (!payload.ok) reject(new Error(payload.message || 'ESP extrema analysis failed'));
+      else resolve(payload.result);
+    }, { once: true });
+    worker.addEventListener('error', (event) => {
+      finish();
+      reject(new Error(event.message || 'ESP extrema worker failed'));
+    }, { once: true });
+    worker.postMessage({
+      requestId,
+      densityCube: pair.density.data,
+      espCube: pair.potential.data,
+      isovalue
+    });
+  });
+}
+
+function cacheEspExtremaResult(key, result) {
+  const cache = state.espAnalysis.extrema.cache;
+  cache.set(key, result);
+  while (cache.size > 8) cache.delete(cache.keys().next().value);
+}
+
+async function ensureEspExtremaForCurrentEsp() {
+  const extrema = state.espAnalysis.extrema;
+  if (!extrema.enabled) return false;
+  const pair = currentEspExtremaPair();
+  if (!pair || !isEspVisualizationActive()) return false;
+  const key = currentEspExtremaKey(pair);
+  const quality = Number(pair.density.gridQuality || state.espAnalysis.quality || 0);
+  const isovalue = Number(pair.density.isovalue || state.espAnalysis.isovalue || 0.001);
+  if (extrema.cache.has(key)) {
+    extrema.result = extrema.cache.get(key);
+    extrema.resultKey = key;
+    extrema.busy = false;
+    syncEspExtremaVisibility();
+    const result = extrema.result;
+    setStatus(`ESP extrema loaded from session cache (${result.minima.length} minima, ${result.maxima.length} maxima)`);
+    return true;
+  }
+
+  extrema.busy = true;
+  syncEspExtremaMenuState();
+  setStatus(`Locating ESP extrema at ${formatGridQuality(quality)}...`);
+  try {
+    const result = await runEspExtremaWorker(pair, isovalue);
+    if (!extrema.enabled || key !== currentEspExtremaKey()) return false;
+    const stored = { ...result, quality, isovalue };
+    cacheEspExtremaResult(key, stored);
+    extrema.result = stored;
+    extrema.resultKey = key;
+    syncEspExtremaVisibility();
+    setStatus(`ESP extrema shown: ${stored.minima.length} minima, ${stored.maxima.length} maxima (${Math.round(stored.elapsedMs)} ms)`);
+    return true;
+  } catch (error) {
+    if (error?.name === 'AbortError') return false;
+    console.error(error);
+    extrema.enabled = false;
+    extrema.result = null;
+    extrema.resultKey = '';
+    clearEspExtremaMarkers({ clearSelection: true });
+    setStatus(error?.message || 'ESP extrema analysis failed', false);
+    return false;
+  } finally {
+    extrema.busy = false;
+    syncEspExtremaMenuState();
+  }
+}
+
+async function setEspExtremaEnabled(enabled, options = {}) {
+  const extrema = state.espAnalysis.extrema;
+  if (!enabled) {
+    extrema.enabled = false;
+    extrema.requestGeneration += 1;
+    disposeEspExtremaWorker('ESP extrema analysis cancelled');
+    extrema.busy = false;
+    clearEspExtremaMarkers({ clearSelection: true });
+    syncEspExtremaMenuState();
+    if (options.announce !== false) setStatus('ESP extrema hidden');
+    return true;
+  }
+
+  const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
+  if (!capability.available) {
+    extrema.enabled = false;
+    syncEspExtremaMenuState();
+    setStatus(capability.reason || 'ESP calculation is unavailable', false);
+    return false;
+  }
+  extrema.enabled = true;
+  syncEspExtremaMenuState();
+
+  const desiredQuality = currentGuiQuality();
+  let pair = currentEspExtremaPair();
+  if (!pair || Number(pair.density.gridQuality) !== desiredQuality) {
+    const loaded = await requestGuiEsp({ quality: desiredQuality });
+    if (!loaded || !extrema.enabled) {
+      extrema.enabled = false;
+      syncEspExtremaMenuState();
+      return false;
+    }
+    pair = currentEspExtremaPair();
+  } else if (!isEspVisualizationActive()) {
+    activateEspLayers(pair.density, pair.potential, {
+      quality: desiredQuality,
+      isovalue: pair.density.isovalue
+    });
+  }
+  if (!pair) {
+    extrema.enabled = false;
+    syncEspExtremaMenuState();
+    setStatus('ESP cube layers are unavailable', false);
+    return false;
+  }
+  return ensureEspExtremaForCurrentEsp();
+}
+
+function setGuiEspRequestBusy(busy) {
+  state.espAnalysis.requestBusy = Boolean(busy);
+  syncBackendRequestControls();
+}
+
+function upsertEspLayer(text, options) {
+  const existing = espLayerByKind(options.analysisKind);
+  const next = layerFromCube(text, options);
+  if (existing) {
+    const id = existing.id;
+    Object.assign(existing, next, { id });
+    return existing;
+  }
+  next.id = state.nextLayerId;
+  state.nextLayerId += 1;
+  state.layers.push(next);
+  state.layers.sort((left, right) => Number(left.id) - Number(right.id));
+  return next;
+}
+
+function activateEspLayers(density, potential, options = {}) {
+  const opacity = clamp(toNumber(density.opacity, state.espAnalysis.opacity), 0.05, 1);
+  state.layers.forEach((layer) => { layer.visible = false; });
+  density.visible = true;
+  density.opacity = opacity;
+  potential.visible = false;
+  density.colorMode = 'cube';
+  density.colorLayerId = String(potential.id);
+  density.gradient = 'trans';
+  state.gui.activeLayerId = String(density.id);
+  state.gui.pendingOrbitalIndex = 0;
+  state.espAnalysis.densityLayerId = String(density.id);
+  state.espAnalysis.potentialLayerId = String(potential.id);
+  state.espAnalysis.quality = Number(density.gridQuality || options.quality || 0);
+  state.espAnalysis.isovalue = Number(density.isovalue || options.isovalue || 0.001);
+  state.espAnalysis.opacity = opacity;
+  renderLayerList();
+  updateLayerSelectors();
+  syncEspOpacityControls();
+  renderScene(false);
+}
+
+function estimateEspColorLimit(densityText, espText, isovalue) {
+  try {
+    const densityVolume = new $3Dmol.VolumeData(densityText, 'cube');
+    const espVolume = new $3Dmol.VolumeData(espText, 'cube');
+    return espScale?.estimateSymmetricRange(densityVolume, espVolume, isovalue, {
+      percentile: 0.95,
+      fallback: 0.05
+    }) || 0.05;
+  } catch (error) {
+    console.error(error);
+    return 0.05;
+  }
+}
+
+async function requestGuiEsp(options = {}) {
+  const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
+  if (!capability.available) {
+    setStatus(capability.reason || 'ESP calculation is unavailable', false);
+    return false;
+  }
+  if (state.gui.orbitalRequestBusy || state.bondAnalysis.requestBusy || state.espAnalysis.requestBusy) {
+    setStatus('Multiwfn backend is busy', false);
+    return false;
+  }
+
+  const existingDensity = espLayerByKind('esp-density');
+  const existingPotential = espLayerByKind('esp-potential');
+  const quality = Number(options.quality || currentGuiQuality());
+  const isovalue = clamp(toNumber(
+    options.isovalue,
+    existingDensity?.isovalue || capability.defaultIsovalue || 0.001
+  ), 0.000001, 0.1);
+  const cached = existingDensity && existingPotential
+    && Number(existingDensity.gridQuality) === quality
+    && Math.abs(Number(existingDensity.isovalue) - isovalue) < 1e-12;
+  if (cached && !options.forceRecompute) {
+    activateEspLayers(existingDensity, existingPotential, { quality, isovalue });
+    setOrbitalStatus(`ESP loaded at ${formatGridQuality(quality)}`);
+    setStatus(`ESP loaded from session cache at ${formatGridQuality(quality)}`);
+    return true;
+  }
+
+  const params = new URLSearchParams({
+    quality: String(quality),
+    isovalue: String(isovalue)
+  });
+  setGuiEspRequestBusy(true);
+  setOrbitalStatus(`Calculating ESP at ${formatGridQuality(quality)}...`);
+  setStatus(`Calculating ESP at ${formatGridQuality(quality)}...`);
+  try {
+    const response = await fetch(`/api/esp?${params.toString()}`, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`ESP API returned HTTP ${response.status}`);
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      throw new Error('ESP API returned invalid JSON');
+    }
+    if (!payload.ok) throw new Error(payload.message || 'ESP calculation failed');
+    const densitySpec = payload.densityLayer;
+    const potentialSpec = payload.espLayer;
+    if (!densitySpec?.path || !potentialSpec?.path) {
+      throw new Error('ESP API response did not include both cube layers');
+    }
+    const sessionUrl = new URL('/session/', window.location.href).toString();
+    const [densityText, potentialText] = await Promise.all([
+      loadTextFromManifestEntry(densitySpec, sessionUrl),
+      loadTextFromManifestEntry(potentialSpec, sessionUrl)
+    ]);
+    const resolvedIsovalue = Number(payload.isovalue || isovalue);
+    const resolvedQuality = Number(payload.quality || quality);
+    const colorLimit = estimateEspColorLimit(densityText, potentialText, resolvedIsovalue);
+    if (
+      (existingDensity && existingDensity.data !== densityText)
+      || (existingPotential && existingPotential.data !== potentialText)
+    ) {
+      invalidateEspExtremaCubeData();
+    }
+    const potential = upsertEspLayer(potentialText, {
+      ...potentialSpec,
+      analysisKind: 'esp-potential',
+      gridQuality: resolvedQuality,
+      role: 'esp',
+      visible: false,
+      positiveColor: espSurfaceColors.positive,
+      negativeColor: espSurfaceColors.negative
+    });
+    const density = upsertEspLayer(densityText, {
+      ...densitySpec,
+      analysisKind: 'esp-density',
+      gridQuality: resolvedQuality,
+      role: 'density',
+      mode: 'positive',
+      isovalue: resolvedIsovalue,
+      opacity: state.espAnalysis.opacity,
+      visible: true,
+      colorMode: 'cube',
+      colorLayerId: String(potential.id),
+      gradient: 'trans',
+      surfaceStyle: 'transparent',
+      colorMin: -colorLimit,
+      colorMax: colorLimit
+    });
+    activateEspLayers(density, potential, { quality: resolvedQuality, isovalue: resolvedIsovalue });
+    setOrbitalStatus(`ESP loaded at ${formatGridQuality(resolvedQuality)}`);
+    setStatus(`ESP mapped at ${formatGridQuality(resolvedQuality)} (±${colorLimit.toPrecision(3)} a.u.)`);
+    return true;
+  } catch (error) {
+    console.error(error);
+    const message = error?.message || 'ESP API unavailable';
+    setStatus(message, false);
+    setOrbitalStatus(message, false);
+    return false;
+  } finally {
+    setGuiEspRequestBusy(false);
+  }
+}
+
 window.multiwfnGui = {
   requestOrbital(index, options = {}) {
     if (Number.isFinite(Number(options.isovalue)) && Number(options.isovalue) > 0) {
@@ -2673,6 +3510,9 @@ window.multiwfnGui = {
   },
   setActiveLayer(id) {
     return setActiveGuiLayer(String(id), { orbitalSelection: true });
+  },
+  requestEsp(options = {}) {
+    return requestGuiEsp(options);
   }
 };
 
@@ -2693,6 +3533,7 @@ function initializeMultiwfnOrbitalSelection() {
 function setStructureData(text, name = 'structure.xyz', format = 'xyz', options = {}) {
   clearAtomSelectionState();
   clearBondAnalysisState({ resetCapabilities: !options.preserveBondCapabilities });
+  resetEspExtremaState({ render: false });
   const normalizedFormat = format === 'auto' ? detectFormat(name) : format;
   state.structure = {
     data: text,
@@ -2714,6 +3555,7 @@ function loadStructure(text, name = 'structure.xyz', format = 'xyz') {
 function clearStructure() {
   clearAtomSelectionState();
   clearBondAnalysisState({ resetCapabilities: true });
+  resetEspExtremaState({ render: false });
   state.structure = { data: '', name: '', format: 'xyz', atoms: 0, baseData: '', bonding: null };
   state.dirtyZoom = true;
   setStatus('Structure cleared');
@@ -2732,6 +3574,8 @@ function layerFromCube(text, options = {}) {
     name: options.name || `${roleLabel(role)}.cube`,
     role,
     orbitalIndex,
+    analysisKind: String(options.analysisKind || ''),
+    gridQuality: Number(options.gridQuality || 0),
     data: text,
     visible: options.visible !== false,
     mode: options.mode || els.surfaceMode.value || 'signed',
@@ -3022,8 +3866,42 @@ function refreshBondAnalysisCapabilities() {
   };
 }
 
+function normalizeEspAnalysisCapabilities(source) {
+  const normalized = defaultEspAnalysisCapabilities();
+  if (!source || typeof source !== 'object') return normalized;
+  normalized.available = Boolean(source.available);
+  normalized.periodicSupported = Boolean(source.periodicSupported);
+  normalized.defaultIsovalue = clamp(toNumber(source.defaultIsovalue, 0.001), 0.000001, 0.1);
+  normalized.reason = String(source.reason || (
+    normalized.available ? '' : 'ESP calculation is unavailable for the current wavefunction'
+  ));
+  return normalized;
+}
+
+function refreshEspAnalysisCapabilities() {
+  const base = state.espAnalysis.baseCapabilities || defaultEspAnalysisCapabilities();
+  const periodicBlocked = Boolean(state.periodic.enabled && !base.periodicSupported);
+  state.espAnalysis.capabilities = {
+    ...base,
+    available: periodicBlocked ? false : Boolean(base.available),
+    reason: periodicBlocked
+      ? 'ESP visualization is not supported for periodic systems'
+      : String(base.reason || '')
+  };
+  if (els.guiToolEspShow) {
+    els.guiToolEspShow.setAttribute('aria-disabled', String(!state.espAnalysis.capabilities.available));
+    els.guiToolEspShow.title = state.espAnalysis.capabilities.available
+      ? ''
+      : state.espAnalysis.capabilities.reason;
+  }
+  if (els.guiToolEsp) els.guiToolEsp.title = state.espAnalysis.capabilities.reason || '';
+  syncEspExtremaMenuState();
+  syncEspOpacityControls();
+}
+
 async function loadManifestObject(manifest, baseUrl = '') {
   state.bondAnalysis.baseCapabilities = normalizeBondAnalysisCapabilities(manifest.bondAnalysis);
+  state.espAnalysis.baseCapabilities = normalizeEspAnalysisCapabilities(manifest.espAnalysis);
   if (manifest.multiwfnGui) {
     state.multiwfnGui = {
       entry: manifest.multiwfnGui.entry || 'standalone',
@@ -3075,6 +3953,7 @@ async function loadManifestObject(manifest, baseUrl = '') {
     els.cubeRepeatCap.value = state.periodic.cubeRepeatCap || 8;
   }
   refreshBondAnalysisCapabilities();
+  refreshEspAnalysisCapabilities();
 
   const structureEntry = manifest.structure;
   const layerEntries = manifest.cubes || manifest.layers || [];
@@ -3104,6 +3983,7 @@ function saveManifest() {
     version: 1,
     multiwfnGui: state.multiwfnGui,
     bondAnalysis: state.bondAnalysis.capabilities,
+    espAnalysis: state.espAnalysis.capabilities,
     structure: state.structure.name
       ? {
           name: state.structure.name,
@@ -3116,6 +3996,8 @@ function saveManifest() {
     layers: state.layers.map((layer) => ({
       name: layer.name,
       role: layer.role,
+      analysisKind: layer.analysisKind || undefined,
+      gridQuality: layer.gridQuality || undefined,
       mode: layer.mode,
       isovalue: layer.isovalue,
       opacity: layer.opacity,
@@ -3166,6 +4048,7 @@ function savePng() {
 function showPlotPanel(show = true) {
   els.plotPanel.classList.toggle('is-hidden', !show);
   updateOrientationVisibility();
+  syncEspExtremaVisibility();
   syncSceneOverlays();
 }
 
@@ -3507,6 +4390,10 @@ function updateLayerFromControl(control) {
     setGlobalOrbitalOpacity(control.value, { announce: true });
     return;
   }
+  if (action === 'opacity' && layer.analysisKind === 'esp-density') {
+    setEspSurfaceOpacity(control.value, { announce: true });
+    return;
+  }
   if (action === 'opacity') layer.opacity = clamp(toNumber(control.value, layer.opacity), 0.05, 1);
   if (action === 'colorMode') layer.colorMode = control.value;
   if (action === 'colorLayerId') layer.colorLayerId = control.value;
@@ -3654,6 +4541,10 @@ function updateActiveLayerFromGui(event) {
   }
   if (event?.target === els.guiIsosurfaceOpacity && isOrbitalLayer(layer)) {
     setGlobalOrbitalOpacity(els.guiIsosurfaceOpacity.value, { announce: true });
+    return;
+  }
+  if (event?.target === els.guiIsosurfaceOpacity && layer.analysisKind === 'esp-density') {
+    setEspSurfaceOpacity(els.guiIsosurfaceOpacity.value, { announce: true });
     return;
   }
   layer.mode = els.guiIsosurfaceMode.value;
@@ -3837,6 +4728,7 @@ function bindEvents() {
   els.guiRotLeft.addEventListener('click', () => rotateGuiView('left'));
   els.guiRotRight.addEventListener('click', () => rotateGuiView('right'));
   els.guiMenuIsosur1.addEventListener('click', () => {
+    setToolsMenuOpen(false);
     setStyleMenuOpen(els.guiIsosur1Menu.hidden, { focus: true });
   });
   els.guiStyleTransparency.addEventListener('click', () => {
@@ -3878,6 +4770,62 @@ function bindEvents() {
     if (els.guiIsosur1Menu.hidden) return;
     setStyleMenuOpen(false);
     els.guiMenuIsosur1.focus();
+    event.preventDefault();
+  });
+
+  els.guiToolsMenu.addEventListener('keydown', handleToolsMenuKeydown);
+  els.guiEspMenu.addEventListener('keydown', handleEspToolsMenuKeydown);
+  els.guiMenuTools.addEventListener('click', () => {
+    setStyleMenuOpen(false);
+    setToolsMenuOpen(els.guiToolsMenu.hidden, { focus: true });
+  });
+  els.guiMenuTools.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+    setToolsMenuOpen(true, { focus: true });
+    event.preventDefault();
+  });
+  els.guiToolEsp.addEventListener('click', () => {
+    setEspToolsMenuOpen(els.guiEspMenu.hidden, { focus: true });
+  });
+  els.guiToolEspShow.addEventListener('click', () => {
+    setToolsMenuOpen(false);
+    const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
+    if (!capability.available) {
+      setStatus(capability.reason || 'ESP calculation is unavailable', false);
+      return;
+    }
+    void requestGuiEsp().then((loaded) => {
+      if (loaded && state.espAnalysis.extrema.enabled) void ensureEspExtremaForCurrentEsp();
+    });
+  });
+  els.guiToolEspExtrema.addEventListener('click', () => {
+    setToolsMenuOpen(false);
+    const capability = state.espAnalysis.capabilities || defaultEspAnalysisCapabilities();
+    if (!capability.available) {
+      setStatus(capability.reason || 'ESP calculation is unavailable', false);
+      return;
+    }
+    void setEspExtremaEnabled(!state.espAnalysis.extrema.enabled);
+  });
+  els.guiEspOpacity.addEventListener('input', () => {
+    setEspSurfaceOpacity(Number(els.guiEspOpacity.value) / 100, { announce: true });
+  });
+  document.addEventListener('click', (event) => {
+    const toolsOpen = !els.guiToolsMenu.hidden || !els.guiEspMenu.hidden;
+    if (toolsOpen && !els.guiToolsMenuControl.contains(event.target)) {
+      setToolsMenuOpen(false);
+    }
+  });
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    if (!els.guiEspMenu.hidden) {
+      closeEspToolsMenu({ focus: true });
+      event.preventDefault();
+      return;
+    }
+    if (els.guiToolsMenu.hidden) return;
+    setToolsMenuOpen(false);
+    els.guiMenuTools.focus();
     event.preventDefault();
   });
 
@@ -4018,13 +4966,18 @@ function bindEvents() {
     els.guiMenuOrbitalInfo,
     els.guiMenuIsosur2,
     els.guiMenuView,
-    els.guiMenuSettings,
-    els.guiMenuTools
+    els.guiMenuSettings
   ].forEach((el) => el.addEventListener('click', () => {
     document.querySelector('.advanced-panels').open = true;
     activateTab(el === els.guiMenuOrbitalInfo || el === els.guiMenuIsosur1 || el === els.guiMenuIsosur2 || el === els.guiMenuQuality ? 'layers' : 'style');
   }));
   els.guiMenuQuality.addEventListener('change', () => {
+    if (isEspVisualizationActive()) {
+      void requestGuiEsp({ forceRecompute: true }).then((loaded) => {
+        if (loaded && state.espAnalysis.extrema.enabled) void ensureEspExtremaForCurrentEsp();
+      });
+      return;
+    }
     const index = Number(activeGuiLayer()?.orbitalIndex || els.guiOrbitalInput.value || 0);
     if (index > 0) requestGuiOrbital(index, { forceRecompute: true });
     else setStatus('Select an orbital before changing grid quality', false);
@@ -4250,6 +5203,14 @@ function cacheElements() {
     guiMenuView: byId('gui-menu-view'),
     guiMenuSettings: byId('gui-menu-settings'),
     guiMenuTools: byId('gui-menu-tools'),
+    guiToolsMenuControl: byId('gui-tools-menu-control'),
+    guiToolsMenu: byId('gui-tools-menu'),
+    guiToolEsp: byId('gui-tool-esp'),
+    guiEspMenu: byId('gui-esp-menu'),
+    guiToolEspShow: byId('gui-tool-esp-show'),
+    guiToolEspExtrema: byId('gui-tool-esp-extrema'),
+    guiEspOpacity: byId('gui-esp-opacity'),
+    guiEspOpacityValue: byId('gui-esp-opacity-value'),
     modelLabel: byId('model-label'),
     cubeLabel: byId('cube-label'),
     structureFile: byId('structure-file'),
@@ -4385,4 +5346,5 @@ window.addEventListener('resize', () => {
   syncSceneOverlays();
   closeBondContextMenu();
   repositionOpenStyleSubmenu();
+  repositionOpenEspToolsMenu();
 });

--- a/frontend/3dmol-viewer/app.js
+++ b/frontend/3dmol-viewer/app.js
@@ -569,7 +569,12 @@ function syncPeriodicFromControls() {
   if (previousStructureKey !== nextStructureKey) {
     clearAtomSelectionState();
     clearBondAnalysisState();
-    resetEspExtremaState({ render: false });
+    const espBase = state.espAnalysis.baseCapabilities || defaultEspAnalysisCapabilities();
+    if (state.periodic.enabled && !espBase.periodicSupported) {
+      removeEspAnalysisLayers({ render: false });
+    } else {
+      resetEspExtremaState({ render: false });
+    }
     refreshBondAnalysisCapabilities();
     refreshEspAnalysisCapabilities();
   }
@@ -2921,6 +2926,31 @@ function espLayerByKind(kind) {
   return state.layers.find((layer) => layer.analysisKind === kind) || null;
 }
 
+function removeEspAnalysisLayers(options = {}) {
+  const removedIds = new Set(
+    state.layers
+      .filter((layer) => layer.analysisKind === 'esp-density' || layer.analysisKind === 'esp-potential')
+      .map((layer) => String(layer.id))
+  );
+  [state.espAnalysis.densityLayerId, state.espAnalysis.potentialLayerId]
+    .filter(Boolean)
+    .forEach((id) => removedIds.add(String(id)));
+  state.layers = state.layers.filter((layer) => !removedIds.has(String(layer.id)));
+  if (removedIds.has(String(state.gui.activeLayerId))) state.gui.activeLayerId = '';
+  state.espAnalysis.densityLayerId = '';
+  state.espAnalysis.potentialLayerId = '';
+  state.espAnalysis.quality = 0;
+  if (state.espAnalysis.opacityFrame) {
+    cancelAnimationFrame(state.espAnalysis.opacityFrame);
+    state.espAnalysis.opacityFrame = 0;
+  }
+  resetEspExtremaState({ render: options.render, clearCache: true });
+  renderLayerList();
+  updateLayerSelectors();
+  syncEspOpacityControls();
+  return removedIds.size > 0;
+}
+
 function isEspVisualizationActive() {
   const density = espLayerByKind('esp-density');
   return Boolean(density?.visible && String(state.gui.activeLayerId) === String(density.id));
@@ -3394,6 +3424,10 @@ async function requestGuiEsp(options = {}) {
     setStatus('Multiwfn backend is busy', false);
     return false;
   }
+  const sessionGeneration = state.espAnalysis.extrema.sessionGeneration;
+  const sessionIsCurrent = () => (
+    sessionGeneration === state.espAnalysis.extrema.sessionGeneration
+  );
 
   const existingDensity = espLayerByKind('esp-density');
   const existingPotential = espLayerByKind('esp-potential');
@@ -3428,6 +3462,7 @@ async function requestGuiEsp(options = {}) {
     } catch (error) {
       throw new Error('ESP API returned invalid JSON');
     }
+    if (!sessionIsCurrent()) return false;
     if (!payload.ok) throw new Error(payload.message || 'ESP calculation failed');
     const densitySpec = payload.densityLayer;
     const potentialSpec = payload.espLayer;
@@ -3439,6 +3474,7 @@ async function requestGuiEsp(options = {}) {
       loadTextFromManifestEntry(densitySpec, sessionUrl),
       loadTextFromManifestEntry(potentialSpec, sessionUrl)
     ]);
+    if (!sessionIsCurrent()) return false;
     const resolvedIsovalue = Number(payload.isovalue || isovalue);
     const resolvedQuality = Number(payload.quality || quality);
     const colorLimit = estimateEspColorLimit(densityText, potentialText, resolvedIsovalue);
@@ -3478,6 +3514,7 @@ async function requestGuiEsp(options = {}) {
     setStatus(`ESP mapped at ${formatGridQuality(resolvedQuality)} (±${colorLimit.toPrecision(3)} a.u.)`);
     return true;
   } catch (error) {
+    if (!sessionIsCurrent()) return false;
     console.error(error);
     const message = error?.message || 'ESP API unavailable';
     setStatus(message, false);

--- a/frontend/3dmol-viewer/esp-extrema-worker.js
+++ b/frontend/3dmol-viewer/esp-extrema-worker.js
@@ -1,0 +1,41 @@
+'use strict';
+
+self.window = self;
+self.document = self.document || {};
+self.$3Dmol = self.$3Dmol || {};
+importScripts('vendor/3Dmol-min.js', 'esp-extrema.js');
+
+const engine = self['3Dmol'] || self.$3Dmol;
+
+self.addEventListener('message', (event) => {
+  const request = event.data || {};
+  const startedAt = performance.now();
+  try {
+    if (!engine?.VolumeData || !engine?.MarchingCube) {
+      throw new Error('3Dmol volume or marching-cubes support is unavailable in the worker');
+    }
+    const density = new engine.VolumeData(String(request.densityCube || ''), 'cube');
+    const esp = new engine.VolumeData(String(request.espCube || ''), 'cube');
+    const triTable = engine.MarchingCube.triTable2 || engine.MarchingCube.triTable;
+    const result = self.MultiwfnEspExtrema.analyzeEspExtrema(
+      density,
+      esp,
+      Number(request.isovalue),
+      { triTable }
+    );
+    self.postMessage({
+      requestId: request.requestId,
+      ok: true,
+      result: {
+        ...result,
+        elapsedMs: performance.now() - startedAt
+      }
+    });
+  } catch (error) {
+    self.postMessage({
+      requestId: request.requestId,
+      ok: false,
+      message: error?.message || 'ESP extrema analysis failed'
+    });
+  }
+});

--- a/frontend/3dmol-viewer/esp-extrema.js
+++ b/frontend/3dmol-viewer/esp-extrema.js
@@ -52,7 +52,12 @@
     if (!expected || densityShape.some((value, index) => value !== espShape[index])) {
       throw new Error('Density and ESP cube dimensions do not match');
     }
-    if (density?.data?.length < expected || esp?.data?.length < expected) {
+    if (
+      !density?.data
+      || !esp?.data
+      || density.data.length < expected
+      || esp.data.length < expected
+    ) {
       throw new Error('Density or ESP cube data is incomplete');
     }
   }
@@ -109,9 +114,18 @@
             index(x + offset[0], y + offset[1], z + offset[2])
           ));
           let cubeIndex = 0;
+          let finiteCorners = true;
           for (let corner = 0; corner < 8; corner += 1) {
-            if (Number(densityData[cornerIndices[corner]]) > iso) cubeIndex |= 1 << corner;
+            const cornerIndex = cornerIndices[corner];
+            const densityValue = Number(densityData[cornerIndex]);
+            const espValue = Number(espData[cornerIndex]);
+            if (!Number.isFinite(densityValue) || !Number.isFinite(espValue)) {
+              finiteCorners = false;
+              break;
+            }
+            if (densityValue > iso) cubeIndex |= 1 << corner;
           }
+          if (!finiteCorners) continue;
           if (cubeIndex === 0 || cubeIndex === 255) continue;
           const triangles = triTable[cubeIndex];
           if (!triangles?.length) continue;

--- a/frontend/3dmol-viewer/esp-extrema.js
+++ b/frontend/3dmol-viewer/esp-extrema.js
@@ -1,0 +1,289 @@
+(function exposeEspExtrema(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.MultiwfnEspExtrema = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, () => {
+  'use strict';
+
+  const KCAL_PER_HARTREE = 627.5094740631;
+  const CORNER_OFFSETS = Object.freeze([
+    [0, 0, 0],
+    [0, 0, 1],
+    [0, 1, 0],
+    [0, 1, 1],
+    [1, 0, 0],
+    [1, 0, 1],
+    [1, 1, 0],
+    [1, 1, 1]
+  ]);
+  const EDGE_CORNERS = Object.freeze([
+    [0, 1],
+    [1, 3],
+    [3, 2],
+    [2, 0],
+    [4, 5],
+    [5, 7],
+    [7, 6],
+    [6, 4],
+    [0, 4],
+    [1, 5],
+    [3, 7],
+    [2, 6]
+  ]);
+
+  function clamp(value, minimum, maximum) {
+    return Math.max(minimum, Math.min(maximum, value));
+  }
+
+  function volumeShape(volume) {
+    return [Number(volume?.size?.x), Number(volume?.size?.y), Number(volume?.size?.z)];
+  }
+
+  function expectedVolumeLength(volume) {
+    const shape = volumeShape(volume);
+    if (!shape.every((value) => Number.isInteger(value) && value > 0)) return 0;
+    return shape.reduce((product, value) => product * value, 1);
+  }
+
+  function assertCompatibleVolumes(density, esp) {
+    const densityShape = volumeShape(density);
+    const espShape = volumeShape(esp);
+    const expected = expectedVolumeLength(density);
+    if (!expected || densityShape.some((value, index) => value !== espShape[index])) {
+      throw new Error('Density and ESP cube dimensions do not match');
+    }
+    if (density?.data?.length < expected || esp?.data?.length < expected) {
+      throw new Error('Density or ESP cube data is incomplete');
+    }
+  }
+
+  function matrixElements(volume) {
+    const elements = volume?.matrixElements || volume?.matrix?.elements;
+    return elements && elements.length === 16 ? elements : null;
+  }
+
+  function gridPointToWorld(volume, x, y, z) {
+    const elements = matrixElements(volume);
+    if (elements) {
+      const denominator = elements[3] * x + elements[7] * y + elements[11] * z + elements[15];
+      const scale = denominator ? 1 / denominator : 1;
+      return {
+        x: (elements[0] * x + elements[4] * y + elements[8] * z + elements[12]) * scale,
+        y: (elements[1] * x + elements[5] * y + elements[9] * z + elements[13]) * scale,
+        z: (elements[2] * x + elements[6] * y + elements[10] * z + elements[14]) * scale
+      };
+    }
+    return {
+      x: Number(volume?.origin?.x || 0) + Number(volume?.unit?.x || 1) * x,
+      y: Number(volume?.origin?.y || 0) + Number(volume?.unit?.y || 1) * y,
+      z: Number(volume?.origin?.z || 0) + Number(volume?.unit?.z || 1) * z
+    };
+  }
+
+  function buildInterpolatedIsosurface(density, esp, isovalue, options = {}) {
+    assertCompatibleVolumes(density, esp);
+    const iso = Number(isovalue);
+    if (!Number.isFinite(iso) || iso <= 0) throw new Error('Density isovalue must be positive');
+    const triTable = options.triTable;
+    if (!triTable || triTable.length < 256) throw new Error('A complete marching-cubes triangle table is required');
+
+    const [nx, ny, nz] = volumeShape(density);
+    const densityData = density.data;
+    const espData = esp.data;
+    const pointCount = nx * ny * nz;
+    const index = (x, y, z) => (x * ny + y) * nz + z;
+    const maximumBoundaryMargin = Math.max(0, Math.floor((Math.min(nx, ny, nz) - 2) / 2));
+    const boundaryMargin = clamp(
+      Number.isFinite(Number(options.boundaryMargin)) ? Math.floor(Number(options.boundaryMargin)) : 1,
+      0,
+      maximumBoundaryMargin
+    );
+    const vertices = [];
+    const faces = [];
+    const edgeVertices = new Map();
+
+    for (let x = 0; x < nx - 1; x += 1) {
+      for (let y = 0; y < ny - 1; y += 1) {
+        for (let z = 0; z < nz - 1; z += 1) {
+          const cornerIndices = CORNER_OFFSETS.map((offset) => (
+            index(x + offset[0], y + offset[1], z + offset[2])
+          ));
+          let cubeIndex = 0;
+          for (let corner = 0; corner < 8; corner += 1) {
+            if (Number(densityData[cornerIndices[corner]]) > iso) cubeIndex |= 1 << corner;
+          }
+          if (cubeIndex === 0 || cubeIndex === 255) continue;
+          const triangles = triTable[cubeIndex];
+          if (!triangles?.length) continue;
+
+          const vertexForEdge = (edgeIndex) => {
+            const pair = EDGE_CORNERS[edgeIndex];
+            if (!pair) throw new Error(`Unsupported marching-cubes edge ${edgeIndex}`);
+            const firstIndex = cornerIndices[pair[0]];
+            const secondIndex = cornerIndices[pair[1]];
+            const low = Math.min(firstIndex, secondIndex);
+            const high = Math.max(firstIndex, secondIndex);
+            const edgeKey = low * pointCount + high;
+            if (edgeVertices.has(edgeKey)) return edgeVertices.get(edgeKey);
+
+            const firstOffset = CORNER_OFFSETS[pair[0]];
+            const secondOffset = CORNER_OFFSETS[pair[1]];
+            const firstDensity = Number(densityData[firstIndex]);
+            const secondDensity = Number(densityData[secondIndex]);
+            const denominator = secondDensity - firstDensity;
+            const fraction = clamp(denominator ? (iso - firstDensity) / denominator : 0.5, 0, 1);
+            const gridX = x + firstOffset[0] + fraction * (secondOffset[0] - firstOffset[0]);
+            const gridY = y + firstOffset[1] + fraction * (secondOffset[1] - firstOffset[1]);
+            const gridZ = z + firstOffset[2] + fraction * (secondOffset[2] - firstOffset[2]);
+            const position = gridPointToWorld(density, gridX, gridY, gridZ);
+            const firstEsp = Number(espData[firstIndex]);
+            const secondEsp = Number(espData[secondIndex]);
+            const value = firstEsp + fraction * (secondEsp - firstEsp);
+            const boundary = (
+              gridX <= boundaryMargin || gridX >= nx - 1 - boundaryMargin
+              || gridY <= boundaryMargin || gridY >= ny - 1 - boundaryMargin
+              || gridZ <= boundaryMargin || gridZ >= nz - 1 - boundaryMargin
+            );
+            const vertexIndex = vertices.length;
+            vertices.push({ ...position, value, boundary });
+            edgeVertices.set(edgeKey, vertexIndex);
+            return vertexIndex;
+          };
+
+          for (let offset = 0; offset + 2 < triangles.length; offset += 3) {
+            const first = vertexForEdge(Number(triangles[offset]));
+            const second = vertexForEdge(Number(triangles[offset + 1]));
+            const third = vertexForEdge(Number(triangles[offset + 2]));
+            if (first === second || second === third || first === third) continue;
+            faces.push(first, second, third);
+          }
+        }
+      }
+    }
+    return { vertices, faces };
+  }
+
+  function buildSurfaceAdjacency(vertexCount, faces) {
+    const adjacency = Array.from({ length: Math.max(0, Number(vertexCount) || 0) }, () => new Set());
+    const connect = (first, second) => {
+      if (first === second || !adjacency[first] || !adjacency[second]) return;
+      adjacency[first].add(second);
+      adjacency[second].add(first);
+    };
+    for (let offset = 0; offset + 2 < faces.length; offset += 3) {
+      const first = Number(faces[offset]);
+      const second = Number(faces[offset + 1]);
+      const third = Number(faces[offset + 2]);
+      connect(first, second);
+      connect(second, third);
+      connect(third, first);
+    }
+    return adjacency;
+  }
+
+  function findSurfaceExtrema(vertices, faces, options = {}) {
+    const adjacency = buildSurfaceAdjacency(vertices.length, faces);
+    const epsilon = Math.max(0, Number(options.epsilon) || 1e-12);
+    const finiteIndices = vertices
+      .map((vertex, index) => (Number.isFinite(Number(vertex?.value)) ? index : -1))
+      .filter((index) => index >= 0);
+    if (!finiteIndices.length) return { minima: [], maxima: [] };
+
+    const neighbourhoods = adjacency.map((directNeighbours, index) => {
+      const neighbours = new Set(directNeighbours);
+      directNeighbours.forEach((directIndex) => {
+        adjacency[directIndex].forEach((secondaryIndex) => {
+          if (secondaryIndex !== index) neighbours.add(secondaryIndex);
+        });
+      });
+      return neighbours;
+    });
+    const excludeBoundary = options.excludeBoundary !== false;
+    const eligibleIndices = finiteIndices.filter((index) => {
+      if (!excludeBoundary) return true;
+      if (vertices[index]?.boundary) return false;
+      return ![...neighbourhoods[index]].some((neighbourIndex) => vertices[neighbourIndex]?.boundary);
+    });
+    const boundaryFiltered = finiteIndices.length - eligibleIndices.length;
+    if (!eligibleIndices.length) return { minima: [], maxima: [], boundaryFiltered };
+
+    let globalMinimumIndex = eligibleIndices[0];
+    let globalMaximumIndex = eligibleIndices[0];
+    eligibleIndices.forEach((index) => {
+      if (Number(vertices[index].value) < Number(vertices[globalMinimumIndex].value)) globalMinimumIndex = index;
+      if (Number(vertices[index].value) > Number(vertices[globalMaximumIndex].value)) globalMaximumIndex = index;
+    });
+
+    const minimumIndices = [];
+    const maximumIndices = [];
+    eligibleIndices.forEach((index) => {
+      if (!adjacency[index].size) return;
+      const neighbours = neighbourhoods[index];
+      const value = Number(vertices[index].value);
+      let isMinimum = true;
+      let isMaximum = true;
+      neighbours.forEach((neighbourIndex) => {
+        const neighbourValue = Number(vertices[neighbourIndex]?.value);
+        if (!Number.isFinite(neighbourValue)) return;
+        if (value >= neighbourValue - epsilon) isMinimum = false;
+        if (value <= neighbourValue + epsilon) isMaximum = false;
+      });
+      if (isMinimum) minimumIndices.push(index);
+      if (isMaximum) maximumIndices.push(index);
+    });
+
+    if (!minimumIndices.includes(globalMinimumIndex)) minimumIndices.push(globalMinimumIndex);
+    if (!maximumIndices.includes(globalMaximumIndex)) maximumIndices.push(globalMaximumIndex);
+    minimumIndices.sort((left, right) => Number(vertices[left].value) - Number(vertices[right].value) || left - right);
+    maximumIndices.sort((left, right) => Number(vertices[right].value) - Number(vertices[left].value) || left - right);
+
+    const format = (index, type, rank, globalIndex) => {
+      const vertex = vertices[index];
+      const value = Number(vertex.value);
+      return {
+        id: `${type === 'minimum' ? 'min' : 'max'}-${rank}`,
+        type,
+        rank,
+        global: index === globalIndex,
+        x: Number(vertex.x),
+        y: Number(vertex.y),
+        z: Number(vertex.z),
+        value,
+        kcalMol: value * KCAL_PER_HARTREE
+      };
+    };
+    return {
+      minima: minimumIndices.map((index, rank) => format(index, 'minimum', rank + 1, globalMinimumIndex)),
+      maxima: maximumIndices.map((index, rank) => format(index, 'maximum', rank + 1, globalMaximumIndex)),
+      boundaryFiltered
+    };
+  }
+
+  function analyzeEspExtrema(density, esp, isovalue, options = {}) {
+    const mesh = buildInterpolatedIsosurface(density, esp, isovalue, options);
+    const extrema = findSurfaceExtrema(mesh.vertices, mesh.faces, options);
+    return {
+      ...extrema,
+      vertexCount: mesh.vertices.length,
+      triangleCount: Math.floor(mesh.faces.length / 3)
+    };
+  }
+
+  function extremaCacheKey(sessionGeneration, quality, isovalue) {
+    const iso = Number(isovalue);
+    return `${Number(sessionGeneration) || 0}:${Number(quality) || 0}:${Number.isFinite(iso) ? iso.toPrecision(12) : 'invalid'}`;
+  }
+
+  return Object.freeze({
+    KCAL_PER_HARTREE,
+    CORNER_OFFSETS,
+    EDGE_CORNERS,
+    analyzeEspExtrema,
+    assertCompatibleVolumes,
+    buildInterpolatedIsosurface,
+    buildSurfaceAdjacency,
+    extremaCacheKey,
+    findSurfaceExtrema,
+    gridPointToWorld
+  });
+}));

--- a/frontend/3dmol-viewer/esp-scale.js
+++ b/frontend/3dmol-viewer/esp-scale.js
@@ -7,6 +7,7 @@
 
   const DEFAULT_LIMIT = 0.05;
   const MINIMUM_LIMIT = 0.005;
+  const KCAL_PER_HARTREE = 627.509474;
   const TRANS_COLORS = Object.freeze({
     negative: '#f5a9b8',
     zero: '#ffffff',
@@ -103,11 +104,43 @@
       : fallback;
   }
 
+  function espLegendTicks(min, max, count = 5) {
+    let lower = Number(min);
+    let upper = Number(max);
+    const tickCount = Math.max(2, Math.floor(Number(count) || 5));
+    if (![lower, upper].every(Number.isFinite) || lower === upper) return [];
+    if (lower > upper) [lower, upper] = [upper, lower];
+
+    const values = Array.from({ length: tickCount }, (_, index) => {
+      const fraction = index / (tickCount - 1);
+      const atomicUnits = upper + fraction * (lower - upper);
+      return {
+        fraction,
+        atomicUnits,
+        kcalMolPerElectron: atomicUnits * KCAL_PER_HARTREE
+      };
+    });
+    const largest = Math.max(...values.map((tick) => Math.abs(tick.kcalMolPerElectron)));
+    const decimals = largest >= 10 ? 1 : largest >= 1 ? 2 : largest >= 0.1 ? 3 : 4;
+    const zeroThreshold = 0.5 * (10 ** -decimals);
+
+    return values.map((tick) => {
+      const value = Math.abs(tick.kcalMolPerElectron) < zeroThreshold ? 0 : tick.kcalMolPerElectron;
+      return {
+        ...tick,
+        kcalMolPerElectron: value,
+        label: value === 0 ? '0' : `${value > 0 ? '+' : ''}${value.toFixed(decimals)}`
+      };
+    });
+  }
+
   return Object.freeze({
     DEFAULT_LIMIT,
     MINIMUM_LIMIT,
+    KCAL_PER_HARTREE,
     TRANS_COLORS,
     transFlagColorHex,
-    estimateSymmetricRange
+    estimateSymmetricRange,
+    espLegendTicks
   });
 }));

--- a/frontend/3dmol-viewer/esp-scale.js
+++ b/frontend/3dmol-viewer/esp-scale.js
@@ -1,0 +1,113 @@
+(function exposeEspScale(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.MultiwfnEspScale = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, () => {
+  'use strict';
+
+  const DEFAULT_LIMIT = 0.05;
+  const MINIMUM_LIMIT = 0.005;
+  const TRANS_COLORS = Object.freeze({
+    negative: '#f5a9b8',
+    zero: '#ffffff',
+    positive: '#5bcefa'
+  });
+
+  function hexChannels(hex) {
+    const value = Number.parseInt(String(hex).replace('#', ''), 16);
+    return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+  }
+
+  function interpolateHex(first, second, fraction) {
+    const start = hexChannels(first);
+    const end = hexChannels(second);
+    const amount = Math.max(0, Math.min(1, Number(fraction) || 0));
+    return start.reduce((value, channel, index) => (
+      value * 256 + Math.round(channel + amount * (end[index] - channel))
+    ), 0);
+  }
+
+  function transFlagColorHex(value, min, max) {
+    const lower = Number(min);
+    const upper = Number(max);
+    const current = Number(value);
+    if (![lower, upper, current].every(Number.isFinite) || lower === upper) return 0xffffff;
+    const clipped = Math.max(Math.min(lower, upper), Math.min(Math.max(lower, upper), current));
+    const midpoint = (lower + upper) / 2;
+    if (clipped <= midpoint) {
+      const width = midpoint - lower;
+      return interpolateHex(TRANS_COLORS.negative, TRANS_COLORS.zero, width ? (clipped - lower) / width : 1);
+    }
+    const width = upper - midpoint;
+    return interpolateHex(TRANS_COLORS.zero, TRANS_COLORS.positive, width ? (clipped - midpoint) / width : 1);
+  }
+
+  function volumeShape(volume) {
+    const size = volume?.size || {};
+    return [Number(size.x), Number(size.y), Number(size.z)];
+  }
+
+  function compatibleVolumes(density, esp) {
+    const densityShape = volumeShape(density);
+    const espShape = volumeShape(esp);
+    const expected = densityShape.reduce((product, value) => product * value, 1);
+    return densityShape.every((value, index) => (
+      Number.isInteger(value) && value > 0 && value === espShape[index]
+    )) && density?.data?.length >= expected && esp?.data?.length >= expected;
+  }
+
+  function estimateSymmetricRange(density, esp, isovalue, options = {}) {
+    const fallback = Math.max(Number(options.fallback) || DEFAULT_LIMIT, MINIMUM_LIMIT);
+    if (!compatibleVolumes(density, esp)) return fallback;
+    const iso = Number(isovalue);
+    if (!Number.isFinite(iso) || iso <= 0) return fallback;
+
+    const [nx, ny, nz] = volumeShape(density);
+    const densityData = density.data;
+    const espData = esp.data;
+    const samples = [];
+    const index = (x, y, z) => x * ny * nz + y * nz + z;
+
+    const sampleEdge = (firstIndex, secondIndex) => {
+      const firstDensity = Number(densityData[firstIndex]);
+      const secondDensity = Number(densityData[secondIndex]);
+      if (!Number.isFinite(firstDensity) || !Number.isFinite(secondDensity)) return;
+      const firstOffset = firstDensity - iso;
+      const secondOffset = secondDensity - iso;
+      if (firstOffset === secondOffset || firstOffset * secondOffset > 0) return;
+      const firstEsp = Number(espData[firstIndex]);
+      const secondEsp = Number(espData[secondIndex]);
+      if (!Number.isFinite(firstEsp) || !Number.isFinite(secondEsp)) return;
+      const fraction = Math.max(0, Math.min(1, -firstOffset / (secondOffset - firstOffset)));
+      const value = firstEsp + fraction * (secondEsp - firstEsp);
+      if (Number.isFinite(value)) samples.push(Math.abs(value));
+    };
+
+    for (let x = 0; x < nx; x += 1) {
+      for (let y = 0; y < ny; y += 1) {
+        for (let z = 0; z < nz; z += 1) {
+          const current = index(x, y, z);
+          if (x + 1 < nx) sampleEdge(current, index(x + 1, y, z));
+          if (y + 1 < ny) sampleEdge(current, index(x, y + 1, z));
+          if (z + 1 < nz) sampleEdge(current, index(x, y, z + 1));
+        }
+      }
+    }
+
+    if (!samples.length) return fallback;
+    samples.sort((left, right) => left - right);
+    const percentile = Math.max(0, Math.min(1, Number(options.percentile) || 0.95));
+    const selected = samples[Math.floor(percentile * (samples.length - 1))];
+    return Number.isFinite(selected) && selected > 0
+      ? Math.max(selected, MINIMUM_LIMIT)
+      : fallback;
+  }
+
+  return Object.freeze({
+    DEFAULT_LIMIT,
+    MINIMUM_LIMIT,
+    TRANS_COLORS,
+    transFlagColorHex,
+    estimateSymmetricRange
+  });
+}));

--- a/frontend/3dmol-viewer/index.html
+++ b/frontend/3dmol-viewer/index.html
@@ -417,6 +417,14 @@
                   <span>Show ESP surface</span>
                 </button>
                 <button
+                  id="gui-tool-esp-legend"
+                  class="gui-style-menu-item"
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked="true"
+                  aria-disabled="true"
+                ><span>Show ESP legend</span><span class="gui-menu-check" aria-hidden="true"></span></button>
+                <button
                   id="gui-tool-esp-extrema"
                   class="gui-style-menu-item"
                   type="button"
@@ -791,6 +799,19 @@
       <section class="viewport-wrap" aria-label="3D viewer">
         <div id="viewer"></div>
         <div id="bond-annotation-layer" class="bond-annotation-layer" aria-live="polite"></div>
+        <aside id="esp-legend" class="esp-legend" aria-labelledby="esp-legend-title" hidden>
+          <div id="esp-legend-header" class="esp-legend-header">
+            <div>
+              <strong id="esp-legend-title">Electrostatic Potential</strong>
+              <span id="esp-legend-unit">(kcal/mol/e)</span>
+            </div>
+            <button id="esp-legend-close" type="button" aria-label="Hide ESP legend" title="Hide ESP legend">&times;</button>
+          </div>
+          <div class="esp-legend-scale">
+            <canvas id="esp-legend-gradient" width="48" height="336" aria-hidden="true"></canvas>
+            <div id="esp-legend-ticks" class="esp-legend-ticks"></div>
+          </div>
+        </aside>
         <div id="bond-context-menu" class="bond-context-menu" role="menu" aria-label="Selected bonds" hidden></div>
         <div id="bond-context-submenu" class="bond-context-menu bond-context-submenu" role="menu" aria-label="Bond properties" hidden></div>
         <div id="orientation-widget" class="orientation-widget" aria-label="Orientation axes"></div>

--- a/frontend/3dmol-viewer/index.html
+++ b/frontend/3dmol-viewer/index.html
@@ -9,6 +9,8 @@
     <script defer src="vendor/3Dmol-min.js"></script>
     <script defer src="cube-coordinates.js"></script>
     <script defer src="bond-perception.js"></script>
+    <script defer src="esp-scale.js"></script>
+    <script defer src="esp-extrema.js"></script>
     <script defer src="app.js"></script>
   </head>
   <body>
@@ -188,6 +190,7 @@
                 <label>
                   <span>Gradient</span>
                   <select id="gui-gradient">
+                    <option value="trans">Trans flag</option>
                     <option value="rwb">Red-white-blue</option>
                     <option value="roygb">Rainbow</option>
                     <option value="sinebow">Sinebow</option>
@@ -390,7 +393,55 @@
             </select>
             <button id="gui-menu-view" type="button">View</button>
             <button id="gui-menu-settings" type="button">Settings</button>
-            <button id="gui-menu-tools" type="button">Tools</button>
+            <div id="gui-tools-menu-control" class="gui-menu-control">
+              <button
+                id="gui-menu-tools"
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded="false"
+                aria-controls="gui-tools-menu"
+              >Tools</button>
+              <div id="gui-tools-menu" class="gui-style-menu gui-tools-menu" role="menu" aria-label="Tools" hidden>
+                <button
+                  id="gui-tool-esp"
+                  class="gui-style-menu-item"
+                  type="button"
+                  role="menuitem"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-controls="gui-esp-menu"
+                ><span>Electrostatic potential (ESP)</span><span aria-hidden="true">&gt;</span></button>
+              </div>
+              <div id="gui-esp-menu" class="gui-style-submenu gui-esp-menu" role="menu" aria-label="ESP controls" hidden>
+                <button id="gui-tool-esp-show" class="gui-style-menu-item" type="button" role="menuitem">
+                  <span>Show ESP surface</span>
+                </button>
+                <button
+                  id="gui-tool-esp-extrema"
+                  class="gui-style-menu-item"
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked="false"
+                ><span>Show ESP extrema</span><span class="gui-menu-check" aria-hidden="true"></span></button>
+                <div class="gui-esp-opacity" role="none">
+                  <label for="gui-esp-opacity">
+                    <span class="gui-opacity-heading">
+                      <span>ESP surface opacity</span>
+                      <output id="gui-esp-opacity-value" for="gui-esp-opacity">88%</output>
+                    </span>
+                    <input
+                      id="gui-esp-opacity"
+                      type="range"
+                      min="5"
+                      max="100"
+                      step="1"
+                      value="88"
+                      aria-valuetext="88%"
+                    >
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/frontend/3dmol-viewer/modern.css
+++ b/frontend/3dmol-viewer/modern.css
@@ -561,6 +561,117 @@ input[type="text"] {
   font: 12px/1.2 var(--ui-font);
 }
 
+.esp-legend {
+  position: absolute;
+  z-index: 5;
+  top: 16px;
+  left: 16px;
+  box-sizing: border-box;
+  width: 184px;
+  padding: 12px;
+  color: var(--text);
+  background: rgba(247, 248, 250, 0.94);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(23, 31, 44, 0.12);
+  backdrop-filter: blur(8px);
+  contain: layout paint;
+}
+
+.esp-legend[hidden] {
+  display: none;
+}
+
+.esp-legend-header {
+  position: relative;
+  padding-right: 22px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.esp-legend.is-dragging .esp-legend-header {
+  cursor: grabbing;
+}
+
+.esp-legend-header strong,
+.esp-legend-header span {
+  display: block;
+  letter-spacing: 0;
+}
+
+.esp-legend-header strong {
+  font: 650 12px/1.2 var(--ui-font);
+  white-space: nowrap;
+}
+
+.esp-legend-header span {
+  margin-top: 2px;
+  color: var(--muted);
+  font: 11px/1.2 var(--ui-font);
+}
+
+.esp-legend-header button {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: grid;
+  place-items: center;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  font: 600 18px/1 var(--ui-font);
+  cursor: pointer;
+}
+
+.esp-legend-header button:hover {
+  color: var(--text);
+  background: var(--panel-soft);
+}
+
+.esp-legend-header button:focus-visible {
+  outline: 0;
+  box-shadow: var(--focus);
+}
+
+.esp-legend-scale {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
+  height: 168px;
+  margin-top: 10px;
+}
+
+.esp-legend-scale canvas {
+  box-sizing: border-box;
+  width: 24px;
+  height: 168px;
+  background: #ffffff;
+  border: 1px solid #b8c0cc;
+  border-radius: 4px;
+}
+
+.esp-legend-ticks {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+  height: 168px;
+  color: var(--text);
+  font: 11px/1 var(--mono-font);
+  font-variant-numeric: tabular-nums;
+}
+
+.esp-legend-ticks span {
+  white-space: nowrap;
+}
+
 .orientation-widget {
   right: 16px;
   bottom: 50px;
@@ -799,5 +910,34 @@ input[type="text"] {
       "left right"
       "up down";
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .esp-legend {
+    top: 10px;
+    left: 10px;
+    width: 152px;
+    padding: 10px;
+  }
+
+  .esp-legend-header strong {
+    font-size: 10px;
+  }
+
+  .esp-legend-header span,
+  .esp-legend-ticks {
+    font-size: 10px;
+  }
+
+  .esp-legend-scale {
+    grid-template-columns: 20px minmax(0, 1fr);
+    gap: 8px;
+    height: 126px;
+    margin-top: 8px;
+  }
+
+  .esp-legend-scale canvas,
+  .esp-legend-ticks {
+    width: 20px;
+    height: 126px;
   }
 }

--- a/frontend/3dmol-viewer/modern.css
+++ b/frontend/3dmol-viewer/modern.css
@@ -189,6 +189,16 @@ body {
   padding: 5px;
 }
 
+.gui-tools-menu {
+  right: 0;
+  left: auto;
+  width: min(260px, calc(100vw - 24px));
+}
+
+.gui-esp-menu {
+  width: min(272px, calc(100vw - 24px));
+}
+
 .gui-style-submenu {
   position: fixed;
   z-index: 13;
@@ -197,6 +207,7 @@ body {
 }
 
 .gui-style-menu .gui-style-menu-item,
+.gui-esp-menu .gui-style-menu-item,
 .gui-background-menu button {
   min-height: 32px;
   padding: 0 8px;
@@ -208,9 +219,21 @@ body {
 
 .gui-style-menu .gui-style-menu-item:hover,
 .gui-style-menu .gui-style-menu-item[aria-expanded="true"],
+.gui-esp-menu .gui-style-menu-item:hover,
+.gui-esp-menu .gui-style-menu-item[aria-expanded="true"],
 .gui-background-menu button:hover,
 .gui-background-menu button[aria-checked="true"] {
   background: var(--accent-soft);
+}
+
+.gui-style-menu .gui-style-menu-item[aria-disabled="true"],
+.gui-esp-menu .gui-style-menu-item[aria-disabled="true"] {
+  color: var(--muted);
+  opacity: 0.62;
+}
+
+.gui-esp-opacity {
+  border-top-color: var(--line);
 }
 
 .gui-menu-check {

--- a/frontend/3dmol-viewer/styles.css
+++ b/frontend/3dmol-viewer/styles.css
@@ -903,6 +903,16 @@ body {
   padding: 2px;
 }
 
+.gui-tools-menu {
+  right: 0;
+  left: auto;
+  width: min(260px, calc(100vw - 16px));
+}
+
+.gui-esp-menu {
+  width: min(260px, calc(100vw - 16px));
+}
+
 .gui-style-submenu {
   position: fixed;
   z-index: 13;
@@ -915,7 +925,8 @@ body {
   display: none;
 }
 
-.gui-style-menu .gui-style-menu-item {
+.gui-style-menu .gui-style-menu-item,
+.gui-esp-menu .gui-style-menu-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -924,8 +935,15 @@ body {
   padding: 0 7px;
 }
 
-.gui-style-menu .gui-style-menu-item[aria-expanded="true"] {
+.gui-style-menu .gui-style-menu-item[aria-expanded="true"],
+.gui-esp-menu .gui-style-menu-item[aria-expanded="true"] {
   background: #d8e7ff;
+}
+
+.gui-style-menu .gui-style-menu-item[aria-disabled="true"],
+.gui-esp-menu .gui-style-menu-item[aria-disabled="true"] {
+  color: #666;
+  opacity: 0.62;
 }
 
 .gui-menu-check {
@@ -949,7 +967,8 @@ body {
   transform: rotate(45deg);
 }
 
-.gui-transparency-menu label {
+.gui-transparency-menu label,
+.gui-esp-opacity label {
   margin: 0;
   font: 700 14px/1.1 var(--ui-font);
 }
@@ -965,10 +984,17 @@ body {
   font: 14px/1.1 var(--mono-font);
 }
 
-.gui-transparency-menu input[type="range"] {
+.gui-transparency-menu input[type="range"],
+.gui-esp-opacity input[type="range"] {
   display: block;
   width: 100%;
   margin-top: 6px;
+}
+
+.gui-esp-opacity {
+  margin-top: 3px;
+  padding: 9px 7px 2px;
+  border-top: 1px solid #aaa;
 }
 
 .gui-background-menu {

--- a/frontend/3dmol-viewer/tests/esp-extrema.test.js
+++ b/frontend/3dmol-viewer/tests/esp-extrema.test.js
@@ -112,3 +112,47 @@ test('rejects incompatible cube dimensions', () => {
     triTable: oneCornerTriangleTable()
   }), /dimensions do not match/);
 });
+
+test('rejects cube volumes with missing or incomplete data arrays', () => {
+  const size = { x: 2, y: 2, z: 2 };
+  const complete = volume(size, new Array(8).fill(0));
+  const missing = { size };
+  const incomplete = volume(size, new Array(7).fill(0));
+  const options = { triTable: oneCornerTriangleTable() };
+
+  assert.throws(
+    () => buildInterpolatedIsosurface(missing, complete, 0.001, options),
+    /cube data is incomplete/
+  );
+  assert.throws(
+    () => buildInterpolatedIsosurface(complete, missing, 0.001, options),
+    /cube data is incomplete/
+  );
+  assert.throws(
+    () => buildInterpolatedIsosurface(incomplete, complete, 0.001, options),
+    /cube data is incomplete/
+  );
+});
+
+test('skips marching-cubes cells containing non-finite density or ESP samples', () => {
+  const size = { x: 2, y: 2, z: 2 };
+  const densityValues = [2, 0, 0, 0, 0, 0, 0, 0];
+  const espValues = [0, 2, 4, 0, 6, 0, 0, 0];
+  const options = { triTable: oneCornerTriangleTable() };
+  const cases = [
+    { density: [NaN, ...densityValues.slice(1)], esp: espValues },
+    { density: densityValues, esp: [Infinity, ...espValues.slice(1)] },
+    { density: densityValues, esp: [-Infinity, ...espValues.slice(1)] }
+  ];
+
+  cases.forEach((sample) => {
+    const mesh = buildInterpolatedIsosurface(
+      volume(size, sample.density),
+      volume(size, sample.esp),
+      1,
+      options
+    );
+    assert.deepEqual(mesh.vertices, []);
+    assert.deepEqual(mesh.faces, []);
+  });
+});

--- a/frontend/3dmol-viewer/tests/esp-extrema.test.js
+++ b/frontend/3dmol-viewer/tests/esp-extrema.test.js
@@ -132,6 +132,10 @@ test('rejects cube volumes with missing or incomplete data arrays', () => {
     () => buildInterpolatedIsosurface(incomplete, complete, 0.001, options),
     /cube data is incomplete/
   );
+  assert.throws(
+    () => buildInterpolatedIsosurface(complete, incomplete, 0.001, options),
+    /cube data is incomplete/
+  );
 });
 
 test('skips marching-cubes cells containing non-finite density or ESP samples', () => {

--- a/frontend/3dmol-viewer/tests/esp-extrema.test.js
+++ b/frontend/3dmol-viewer/tests/esp-extrema.test.js
@@ -1,0 +1,114 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildInterpolatedIsosurface,
+  extremaCacheKey,
+  findSurfaceExtrema,
+  gridPointToWorld
+} = require('../esp-extrema.js');
+
+function volume(size, data, options = {}) {
+  return {
+    size,
+    data: Float32Array.from(data),
+    origin: options.origin || { x: 0, y: 0, z: 0 },
+    unit: options.unit || { x: 1, y: 1, z: 1 },
+    matrixElements: options.matrixElements || null
+  };
+}
+
+function oneCornerTriangleTable() {
+  const table = Array.from({ length: 256 }, () => []);
+  table[1] = [0, 3, 8];
+  return table;
+}
+
+test('interpolates surface positions and ESP values along density crossing edges', () => {
+  const size = { x: 2, y: 2, z: 2 };
+  const density = volume(size, [2, 0, 0, 0, 0, 0, 0, 0]);
+  const esp = volume(size, [0, 2, 4, 0, 6, 0, 0, 0]);
+  const mesh = buildInterpolatedIsosurface(density, esp, 1, {
+    triTable: oneCornerTriangleTable()
+  });
+
+  assert.equal(mesh.vertices.length, 3);
+  assert.deepEqual(mesh.faces, [0, 1, 2]);
+  const byValue = [...mesh.vertices].sort((left, right) => left.value - right.value);
+  assert.deepEqual(byValue.map((point) => point.value), [1, 2, 3]);
+  assert.deepEqual(byValue[0], { x: 0, y: 0, z: 0.5, value: 1, boundary: true });
+  assert.deepEqual(byValue[1], { x: 0, y: 0.5, z: 0, value: 2, boundary: true });
+  assert.deepEqual(byValue[2], { x: 0.5, y: 0, z: 0, value: 3, boundary: true });
+});
+
+test('uses cube matrix coordinates when present', () => {
+  const point = gridPointToWorld({
+    matrixElements: [
+      2, 0, 0, 0,
+      0, 3, 0, 0,
+      0, 0, 4, 0,
+      5, 6, 7, 1
+    ]
+  }, 1, 2, 3);
+  assert.deepEqual(point, { x: 7, y: 12, z: 19 });
+});
+
+test('rejects a pseudo-minimum that has a lower second-order neighbour', () => {
+  const vertices = [
+    { x: 0, y: 0, z: 0, value: 0 },
+    { x: 1, y: 0, z: 0, value: 1 },
+    { x: 2, y: 0, z: 0, value: -1 },
+    { x: 1, y: 1, z: 0, value: 2 }
+  ];
+  const result = findSurfaceExtrema(vertices, [0, 1, 3, 1, 2, 3]);
+  assert.deepEqual(result.minima.map((point) => point.value), [-1]);
+  assert.deepEqual(result.maxima.map((point) => point.value), [2]);
+  assert.equal(result.minima[0].global, true);
+  assert.equal(result.maxima[0].global, true);
+});
+
+test('always includes deterministic global extrema on a flat surface', () => {
+  const vertices = [
+    { x: 0, y: 0, z: 0, value: 1 },
+    { x: 1, y: 0, z: 0, value: 1 },
+    { x: 0, y: 1, z: 0, value: 1 }
+  ];
+  const result = findSurfaceExtrema(vertices, [0, 1, 2]);
+  assert.equal(result.minima.length, 1);
+  assert.equal(result.maxima.length, 1);
+  assert.equal(result.minima[0].id, 'min-1');
+  assert.equal(result.maxima[0].id, 'max-1');
+  assert.equal(result.minima[0].global, true);
+  assert.equal(result.maxima[0].global, true);
+});
+
+test('filters extrema on the outer grid shell and its surface neighbourhood', () => {
+  const vertices = [
+    { x: 0, y: 0, z: 0, value: -10, boundary: true },
+    { x: 1, y: 0, z: 0, value: -9 },
+    { x: 0, y: 1, z: 0, value: -8 },
+    { x: 3, y: 0, z: 0, value: -2 },
+    { x: 4, y: 0, z: 0, value: 0 },
+    { x: 3, y: 1, z: 0, value: 2 }
+  ];
+  const result = findSurfaceExtrema(vertices, [0, 1, 2, 3, 4, 5]);
+  assert.deepEqual(result.minima.map((point) => point.value), [-2]);
+  assert.deepEqual(result.maxima.map((point) => point.value), [2]);
+  assert.equal(result.boundaryFiltered, 3);
+});
+
+test('cache keys vary by structure session, quality, and isovalue', () => {
+  const baseline = extremaCacheKey(2, 120000, 0.001);
+  assert.equal(baseline, extremaCacheKey(2, 120000, 0.001));
+  assert.notEqual(baseline, extremaCacheKey(3, 120000, 0.001));
+  assert.notEqual(baseline, extremaCacheKey(2, 300000, 0.001));
+  assert.notEqual(baseline, extremaCacheKey(2, 120000, 0.002));
+});
+
+test('rejects incompatible cube dimensions', () => {
+  const density = volume({ x: 2, y: 2, z: 2 }, new Array(8).fill(0));
+  const esp = volume({ x: 2, y: 2, z: 1 }, new Array(4).fill(0));
+  assert.throws(() => buildInterpolatedIsosurface(density, esp, 0.001, {
+    triTable: oneCornerTriangleTable()
+  }), /dimensions do not match/);
+});

--- a/frontend/3dmol-viewer/tests/esp-scale.test.js
+++ b/frontend/3dmol-viewer/tests/esp-scale.test.js
@@ -1,7 +1,12 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { estimateSymmetricRange, transFlagColorHex } = require('../esp-scale.js');
+const {
+  KCAL_PER_HARTREE,
+  espLegendTicks,
+  estimateSymmetricRange,
+  transFlagColorHex
+} = require('../esp-scale.js');
 
 function volume(size, data) {
   return { size, data: Float32Array.from(data) };
@@ -39,4 +44,19 @@ test('maps negative, zero, and positive ESP to exact trans flag colors', () => {
   assert.equal(transFlagColorHex(-0.05, -0.05, 0.05), 0xf5a9b8);
   assert.equal(transFlagColorHex(0, -0.05, 0.05), 0xffffff);
   assert.equal(transFlagColorHex(0.05, -0.05, 0.05), 0x5bcefa);
+});
+
+test('builds signed kcal/mol/e legend ticks from the active ESP range', () => {
+  const ticks = espLegendTicks(-0.0533, 0.0533);
+  assert.equal(ticks.length, 5);
+  assert.deepEqual(ticks.map((tick) => tick.label), ['+33.4', '+16.7', '0', '-16.7', '-33.4']);
+  assert.ok(Math.abs(ticks[0].kcalMolPerElectron - 0.0533 * KCAL_PER_HARTREE) < 1e-10);
+  assert.equal(ticks[0].fraction, 0);
+  assert.equal(ticks[4].fraction, 1);
+});
+
+test('formats small and asymmetric ESP legend ranges without forcing symmetry', () => {
+  const ticks = espLegendTicks(-0.0002, 0.0004, 3);
+  assert.deepEqual(ticks.map((tick) => tick.label), ['+0.251', '+0.063', '-0.126']);
+  assert.deepEqual(espLegendTicks(1, 1), []);
 });

--- a/frontend/3dmol-viewer/tests/esp-scale.test.js
+++ b/frontend/3dmol-viewer/tests/esp-scale.test.js
@@ -1,0 +1,42 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { estimateSymmetricRange, transFlagColorHex } = require('../esp-scale.js');
+
+function volume(size, data) {
+  return { size, data: Float32Array.from(data) };
+}
+
+test('interpolates ESP where the density isosurface crosses grid edges', () => {
+  const size = { x: 2, y: 1, z: 1 };
+  const density = volume(size, [0, 2]);
+  const esp = volume(size, [-0.2, 0.4]);
+  assert.ok(Math.abs(estimateSymmetricRange(density, esp, 1) - 0.1) < 1e-7);
+});
+
+test('uses a robust percentile instead of a single surface outlier', () => {
+  const size = { x: 6, y: 1, z: 1 };
+  const density = volume(size, [0, 2, 0, 2, 0, 2]);
+  const esp = volume(size, [-0.04, 0.04, -0.04, 0.04, -0.04, 10]);
+  assert.ok(estimateSymmetricRange(density, esp, 1) < 1);
+});
+
+test('falls back for incompatible volumes or a missing crossing', () => {
+  const density = volume({ x: 2, y: 1, z: 1 }, [0, 0]);
+  const esp = volume({ x: 2, y: 1, z: 1 }, [1, 1]);
+  assert.equal(estimateSymmetricRange(density, esp, 1), 0.05);
+  assert.equal(estimateSymmetricRange(density, volume({ x: 1, y: 1, z: 1 }, [1]), 1), 0.05);
+});
+
+test('ignores a trailing parser value beyond the declared cube dimensions', () => {
+  const size = { x: 2, y: 1, z: 1 };
+  const density = volume(size, [0, 2, Number.NaN]);
+  const esp = volume(size, [-0.2, 0.4, Number.NaN]);
+  assert.ok(Math.abs(estimateSymmetricRange(density, esp, 1) - 0.1) < 1e-7);
+});
+
+test('maps negative, zero, and positive ESP to exact trans flag colors', () => {
+  assert.equal(transFlagColorHex(-0.05, -0.05, 0.05), 0xf5a9b8);
+  assert.equal(transFlagColorHex(0, -0.05, 0.05), 0xffffff);
+  assert.equal(transFlagColorHex(0.05, -0.05, 0.05), 0x5bcefa);
+});

--- a/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
+++ b/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import http.server
 import json
+import math
 import mimetypes
 import os
 from pathlib import Path
@@ -158,9 +159,11 @@ BACKEND_REQUEST_CONSUME_TIMEOUT = 5.0
 ORBITAL_REQUEST_TIMEOUT = 300.0
 BOND_REQUEST_TIMEOUT = 300.0
 FBO_REQUEST_TIMEOUT = 900.0
+ESP_REQUEST_TIMEOUT = 900.0
 BACKEND_REQUEST_POLL_INTERVAL = 0.2
 MAX_DYNAMIC_ORBITAL_CUBES = 12
 BOND_METHODS = frozenset(("mayer", "gwbo", "wiberg_lowdin", "mulliken", "fbo"))
+ESP_QUALITY_LEVELS = frozenset((25000, 50000, 120000, 300000, 500000, 1000000, 1500000))
 LAST_REQUEST_ID = 0
 BACKEND_UNAVAILABLE_MESSAGE = (
     "Multiwfn backend unavailable; restart visualization from menu 0 and keep the terminal open"
@@ -203,7 +206,7 @@ def send_json(handler: http.server.BaseHTTPRequestHandler, payload: dict, status
 def cleanup_session_files(session_dir: Path, *, startup: bool = False) -> None:
     patterns = ["response_*.json"]
     if startup:
-        patterns.append("orbital_*.cube")
+        patterns.extend(("orbital_*.cube", "esp_density_*.cube", "esp_potential_*.cube"))
     for pattern in patterns:
         for path in session_dir.glob(pattern):
             try:
@@ -223,6 +226,22 @@ def prune_dynamic_orbital_cubes(session_dir: Path, keep: int = MAX_DYNAMIC_ORBIT
             path.unlink()
         except OSError:
             pass
+
+
+def prune_dynamic_esp_cubes(session_dir: Path, payload: dict) -> None:
+    keep = {
+        Path(str(layer.get("path", ""))).name
+        for layer in (payload.get("densityLayer", {}), payload.get("espLayer", {}))
+        if isinstance(layer, dict) and layer.get("path")
+    }
+    for pattern in ("esp_density_*.cube", "esp_potential_*.cube"):
+        for path in session_dir.glob(pattern):
+            if path.name in keep:
+                continue
+            try:
+                path.unlink()
+            except OSError:
+                pass
 
 
 def next_request_id() -> int:
@@ -319,6 +338,27 @@ def request_bond(session_dir: Path, query: dict[str, list[str]]) -> dict:
     )
 
 
+def request_esp(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    try:
+        quality = int(query.get("quality", ["120000"])[0] or 120000)
+        isovalue = float(query.get("isovalue", ["0.001"])[0] or 0.001)
+    except ValueError:
+        return {"ok": False, "message": "ESP quality and isovalue must be numeric"}
+    if quality not in ESP_QUALITY_LEVELS:
+        return {"ok": False, "message": "Unsupported ESP grid quality"}
+    if not math.isfinite(isovalue) or isovalue <= 0.0 or isovalue > 0.1:
+        return {"ok": False, "message": "ESP density isovalue must be between 0 and 0.1 a.u."}
+    payload = request_backend(
+        session_dir,
+        f"esp {quality} {isovalue:.10g}",
+        timeout=ESP_REQUEST_TIMEOUT,
+        timeout_message="Timed out waiting for Multiwfn ESP calculation",
+    )
+    if payload.get("ok"):
+        prune_dynamic_esp_cubes(session_dir, payload)
+    return payload
+
+
 class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     daemon_threads = True
 
@@ -368,6 +408,12 @@ def make_handler(frontend_dir: Path, session_dir: Path, manifest: Path):
             if request_path == "/api/bond":
                 try:
                     send_json(self, request_bond(session_dir, query))
+                except Exception as exc:
+                    send_json(self, {"ok": False, "message": str(exc)}, status=500)
+                return
+            if request_path == "/api/esp":
+                try:
+                    send_json(self, request_esp(session_dir, query))
                 except Exception as exc:
                     send_json(self, {"ok": False, "message": str(exc)}, status=500)
                 return

--- a/noGUI/GUI_3dmol.f90
+++ b/noGUI/GUI_3dmol.f90
@@ -601,8 +601,12 @@ character(len=*),intent(in) :: session,respfile
 integer,intent(in) :: quality
 real*8,intent(in) :: isoval
 character(len=512) :: densityfile,densityrel,espfile,esprel
-integer :: iu
-real*8 :: esprhoiso_org
+integer :: iu,nprevorbgrid_org,nx_org,ny_org,nz_org,iorbsel_org
+real*8 :: esprhoiso_org,orgx_org,orgy_org,orgz_org,endx_org,endy_org,endz_org
+real*8 :: dx_org,dy_org,dz_org,gridv1_org(3),gridv2_org(3),gridv3_org(3)
+real*8 :: nelec_org,naelec_org,nbelec_org
+real*8,allocatable :: cubmat_org(:,:,:)
+logical :: cubmat_was_allocated
 
 if (ifPBC>0) then
     call write_gui_json_error(respfile,"ESP visualization is not supported for periodic systems")
@@ -622,9 +626,32 @@ if (isoval<=0D0.or.isoval>0.1D0) then
     return
 end if
 
+nprevorbgrid_org=nprevorbgrid
+nx_org=nx
+ny_org=ny
+nz_org=nz
+iorbsel_org=iorbsel
+orgx_org=orgx
+orgy_org=orgy
+orgz_org=orgz
+endx_org=endx
+endy_org=endy
+endz_org=endz
+dx_org=dx
+dy_org=dy
+dz_org=dz
+gridv1_org=gridv1
+gridv2_org=gridv2
+gridv3_org=gridv3
+esprhoiso_org=ESPrhoiso
+nelec_org=nelec
+naelec_org=naelec
+nbelec_org=nbelec
+cubmat_was_allocated=allocated(cubmat)
+if (cubmat_was_allocated) call move_alloc(cubmat,cubmat_org)
+
 nprevorbgrid=quality
 call setup_orbital_grid()
-if (allocated(cubmat)) deallocate(cubmat)
 allocate(cubmat(nx,ny,nz))
 call savecubmat(1,1,0)
 
@@ -632,14 +659,36 @@ write(densityrel,"('esp_density_',i0,'.cube')") quality
 densityfile=trim(session)//"/"//trim(densityrel)
 call write_cube(trim(densityfile),cubmat)
 
-esprhoiso_org=ESPrhoiso
 ESPrhoiso=isoval
 call savecubmat(12,1,0)
-ESPrhoiso=esprhoiso_org
 
 write(esprel,"('esp_potential_',i0,'.cube')") quality
 espfile=trim(session)//"/"//trim(esprel)
 call write_cube(trim(espfile),cubmat)
+
+if (allocated(cubmat)) deallocate(cubmat)
+if (cubmat_was_allocated) call move_alloc(cubmat_org,cubmat)
+nprevorbgrid=nprevorbgrid_org
+nx=nx_org
+ny=ny_org
+nz=nz_org
+iorbsel=iorbsel_org
+orgx=orgx_org
+orgy=orgy_org
+orgz=orgz_org
+endx=endx_org
+endy=endy_org
+endz=endz_org
+dx=dx_org
+dy=dy_org
+dz=dz_org
+gridv1=gridv1_org
+gridv2=gridv2_org
+gridv3=gridv3_org
+ESPrhoiso=esprhoiso_org
+nelec=nelec_org
+naelec=naelec_org
+nbelec=nbelec_org
 
 open(newunit=iu,file=trim(respfile),status="replace",action="write")
 write(iu,"(a)") "{"
@@ -669,7 +718,6 @@ write(iu,"(a)") '    "visible": false'
 write(iu,"(a)") '  }'
 write(iu,"(a)") "}"
 close(iu)
-if (allocated(cubmat)) deallocate(cubmat)
 end subroutine
 
 subroutine handle_bond_request(respfile,iatm1,iatm2,method)

--- a/noGUI/GUI_3dmol.f90
+++ b/noGUI/GUI_3dmol.f90
@@ -326,6 +326,13 @@ do
                     else
                         call write_gui_json_error(trim(respfile),"Malformed bond request")
                     end if
+                else if (trim(action)=="esp") then
+                    read(line,*,iostat=istat) reqid,action,quality,isoval
+                    if (istat==0) then
+                        call handle_esp_request(trim(session),trim(respfile),quality,isoval)
+                    else
+                        call write_gui_json_error(trim(respfile),"Malformed ESP request")
+                    end if
                 else
                     call write_gui_json_error(trim(respfile),"Unknown GUI request")
                 end if
@@ -395,6 +402,82 @@ write(iu,"(a)") '    "visible": true'
 write(iu,"(a)") '  }'
 write(iu,"(a)") "}"
 close(iu)
+end subroutine
+
+subroutine handle_esp_request(session,respfile,quality,isoval)
+character(len=*),intent(in) :: session,respfile
+integer,intent(in) :: quality
+real*8,intent(in) :: isoval
+character(len=512) :: densityfile,densityrel,espfile,esprel
+integer :: iu
+real*8 :: esprhoiso_org
+
+if (ifPBC>0) then
+    call write_gui_json_error(respfile,"ESP visualization is not supported for periodic systems")
+    return
+end if
+if (.not.allocated(a).or.ncenter<=0.or..not.allocated(b).or.nprims<=0.or. &
+    .not.allocated(CO).or.nmo<=0) then
+    call write_gui_json_error(respfile,"Wavefunction and GTF information is unavailable for ESP calculation")
+    return
+end if
+if (quality<25000.or.quality>1500000) then
+    call write_gui_json_error(respfile,"ESP grid quality is out of range")
+    return
+end if
+if (isoval<=0D0.or.isoval>0.1D0) then
+    call write_gui_json_error(respfile,"ESP density isovalue is out of range")
+    return
+end if
+
+nprevorbgrid=quality
+call setup_orbital_grid()
+if (allocated(cubmat)) deallocate(cubmat)
+allocate(cubmat(nx,ny,nz))
+call savecubmat(1,1,0)
+
+write(densityrel,"('esp_density_',i0,'.cube')") quality
+densityfile=trim(session)//"/"//trim(densityrel)
+call write_cube(trim(densityfile),cubmat)
+
+esprhoiso_org=ESPrhoiso
+ESPrhoiso=isoval
+call savecubmat(12,1,0)
+ESPrhoiso=esprhoiso_org
+
+write(esprel,"('esp_potential_',i0,'.cube')") quality
+espfile=trim(session)//"/"//trim(esprel)
+call write_cube(trim(espfile),cubmat)
+
+open(newunit=iu,file=trim(respfile),status="replace",action="write")
+write(iu,"(a)") "{"
+write(iu,"(a)") '  "ok": true,'
+write(iu,"(a,i0,a)") '  "quality": ',quality,','
+write(iu,"(a,es24.16,a)") '  "isovalue": ',isoval,','
+write(iu,"(a)") '  "densityLayer": {'
+write(iu,"(a)") '    "name": "ESP on electron density",'
+write(iu,"(a,a,a)") '    "path": "',trim(densityrel),'",'
+write(iu,"(a)") '    "role": "density",'
+write(iu,"(a)") '    "analysisKind": "esp-density",'
+write(iu,"(a,i0,a)") '    "gridQuality": ',quality,','
+write(iu,"(a)") '    "mode": "positive",'
+write(iu,"(a,es24.16,a)") '    "isovalue": ',isoval,','
+write(iu,"(a)") '    "opacity": 0.88,'
+write(iu,"(a)") '    "visible": true'
+write(iu,"(a)") '  },'
+write(iu,"(a)") '  "espLayer": {'
+write(iu,"(a)") '    "name": "Electrostatic potential",'
+write(iu,"(a,a,a)") '    "path": "',trim(esprel),'",'
+write(iu,"(a)") '    "role": "esp",'
+write(iu,"(a)") '    "analysisKind": "esp-potential",'
+write(iu,"(a,i0,a)") '    "gridQuality": ',quality,','
+write(iu,"(a)") '    "mode": "signed",'
+write(iu,"(a)") '    "isovalue": 0.02,'
+write(iu,"(a)") '    "visible": false'
+write(iu,"(a)") '  }'
+write(iu,"(a)") "}"
+close(iu)
+if (allocated(cubmat)) deallocate(cubmat)
 end subroutine
 
 subroutine handle_bond_request(respfile,iatm1,iatm2,method)
@@ -829,6 +912,7 @@ else
     write(iu,"(a)") '  "structure": null,'
 end if
 call write_bond_analysis_manifest(iu)
+call write_esp_analysis_manifest(iu)
 if (ifPBC>0) then
     write(iu,"(a)") '  "periodic": {'
     write(iu,"(a)") '    "enabled": true,'
@@ -887,6 +971,27 @@ call write_bond_method_capability(iu,"wiberg_lowdin",basisok,basisreason,.true.)
 call write_bond_method_capability(iu,"mulliken",basisok,basisreason,.true.)
 call write_bond_method_capability(iu,"fbo",fbook,fboreason,.false.)
 write(iu,"(a)") '    }'
+write(iu,"(a)") '  },'
+end subroutine
+
+subroutine write_esp_analysis_manifest(iu)
+integer,intent(in) :: iu
+logical :: available
+character(len=96) :: reason
+
+available=ifPBC==0.and.allocated(a).and.ncenter>0.and.allocated(b).and.nprims>0.and. &
+    allocated(CO).and.nmo>0
+if (ifPBC>0) then
+    reason="ESP visualization is not supported for periodic systems"
+else
+    reason="Wavefunction and GTF information is unavailable for ESP calculation"
+end if
+
+write(iu,"(a)") '  "espAnalysis": {'
+write(iu,"(a)") '    "periodicSupported": false,'
+write(iu,"(a,a,a)") '    "available": ',trim(json_bool(available)),','
+if (.not.available) write(iu,"(a,a,a)") '    "reason": "',trim(reason),'",'
+write(iu,"(a)") '    "defaultIsovalue": 0.001'
 write(iu,"(a)") '  },'
 end subroutine
 

--- a/tools/multiwfn_3dmol_server.py
+++ b/tools/multiwfn_3dmol_server.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import http.server
 import json
+import math
 import mimetypes
 from pathlib import Path
 import platform
@@ -25,9 +26,11 @@ BACKEND_REQUEST_CONSUME_TIMEOUT = 5.0
 ORBITAL_REQUEST_TIMEOUT = 300.0
 BOND_REQUEST_TIMEOUT = 300.0
 FBO_REQUEST_TIMEOUT = 900.0
+ESP_REQUEST_TIMEOUT = 900.0
 BACKEND_REQUEST_POLL_INTERVAL = 0.2
 MAX_DYNAMIC_ORBITAL_CUBES = 12
 BOND_METHODS = frozenset(("mayer", "gwbo", "wiberg_lowdin", "mulliken", "fbo"))
+ESP_QUALITY_LEVELS = frozenset((25000, 50000, 120000, 300000, 500000, 1000000, 1500000))
 LAST_REQUEST_ID = 0
 BACKEND_UNAVAILABLE_MESSAGE = (
     "Multiwfn backend unavailable; restart visualization from menu 0 and keep the terminal open"
@@ -74,7 +77,7 @@ def send_json(handler: http.server.BaseHTTPRequestHandler, payload: dict, status
 def cleanup_session_files(session_dir: Path, *, startup: bool = False) -> None:
     patterns = ["response_*.json"]
     if startup:
-        patterns.append("orbital_*.cube")
+        patterns.extend(("orbital_*.cube", "esp_density_*.cube", "esp_potential_*.cube"))
     for pattern in patterns:
         for path in session_dir.glob(pattern):
             try:
@@ -94,6 +97,22 @@ def prune_dynamic_orbital_cubes(session_dir: Path, keep: int = MAX_DYNAMIC_ORBIT
             path.unlink()
         except OSError:
             pass
+
+
+def prune_dynamic_esp_cubes(session_dir: Path, payload: dict) -> None:
+    keep = {
+        Path(str(layer.get("path", ""))).name
+        for layer in (payload.get("densityLayer", {}), payload.get("espLayer", {}))
+        if isinstance(layer, dict) and layer.get("path")
+    }
+    for pattern in ("esp_density_*.cube", "esp_potential_*.cube"):
+        for path in session_dir.glob(pattern):
+            if path.name in keep:
+                continue
+            try:
+                path.unlink()
+            except OSError:
+                pass
 
 
 def next_request_id() -> int:
@@ -190,6 +209,27 @@ def request_bond(session_dir: Path, query: dict[str, list[str]]) -> dict:
     )
 
 
+def request_esp(session_dir: Path, query: dict[str, list[str]]) -> dict:
+    try:
+        quality = int(query.get("quality", ["120000"])[0] or 120000)
+        isovalue = float(query.get("isovalue", ["0.001"])[0] or 0.001)
+    except ValueError:
+        return {"ok": False, "message": "ESP quality and isovalue must be numeric"}
+    if quality not in ESP_QUALITY_LEVELS:
+        return {"ok": False, "message": "Unsupported ESP grid quality"}
+    if not math.isfinite(isovalue) or isovalue <= 0.0 or isovalue > 0.1:
+        return {"ok": False, "message": "ESP density isovalue must be between 0 and 0.1 a.u."}
+    payload = request_backend(
+        session_dir,
+        f"esp {quality} {isovalue:.10g}",
+        timeout=ESP_REQUEST_TIMEOUT,
+        timeout_message="Timed out waiting for Multiwfn ESP calculation",
+    )
+    if payload.get("ok"):
+        prune_dynamic_esp_cubes(session_dir, payload)
+    return payload
+
+
 def is_wsl() -> bool:
     try:
         release = Path("/proc/sys/kernel/osrelease").read_text(encoding="utf-8", errors="ignore")
@@ -279,6 +319,13 @@ def make_handler(frontend_dir: Path, session_dir: Path, manifest: Path):
             if request_path == "/api/bond":
                 try:
                     send_json(self, request_bond(session_dir, query))
+                except Exception as exc:
+                    send_json(self, {"ok": False, "message": str(exc)}, status=500)
+                return
+
+            if request_path == "/api/esp":
+                try:
+                    send_json(self, request_esp(session_dir, query))
                 except Exception as exc:
                     send_json(self, {"ok": False, "message": str(exc)}, status=500)
                 return


### PR DESCRIPTION
## Summary

- move atom multi-selection to Command-click on macOS and Ctrl-click on Windows/Linux while keeping right-click dedicated to bond-property menus
- add serialized Multiwfn-backed ESP analysis that generates matched density and potential cubes at the selected grid quality
- map ESP onto the 0.001 a.u. density surface with the trans-flag pink-white-blue gradient and preserve orbitals, camera, atom selections, and bond annotations
- add a Tools > Electrostatic potential submenu with ESP display, in-place surface opacity, extrema controls, and a dynamic kcal/mol/e legend
- make the light ESP legend draggable within the viewport and include its live position, colors, and range in PNG exports without the close control
- detect surface extrema in an offline Web Worker using interpolated marching-cubes topology, reject boundary artifacts and incomplete volume data, cache results, and show signed a.u./kcal mol-1 values on click

## Implementation notes

- keeps manifest version 2 and the existing request/response file protocol
- adds `/api/esp?quality=...&isovalue=...` to both browser and Qt services
- serializes ESP, orbital, and bond-order requests through the shared backend lock
- restores Multiwfn grid state and discards stale ESP results across structure or periodic-session changes
- updates ESP opacity, extrema markers, and legend position without rebuilding the density isosurface
- supports Pointer Events plus a mouse fallback for Qt WebEngine legend dragging
- keeps `agent.md`, `settings.ini`, build outputs, and visualization sessions out of the commit

## Validation

- `node --test frontend/3dmol-viewer/tests/*.test.js` (36 passing)
- JavaScript and Python syntax checks for the GUI services
- unique HTML ID and `git diff --check` checks
- `cmake --build build-qt-gui -j2`
- browser and Qt WebEngine verification with benzene and `PcG0.fchk`
- PcG0 legend ranges verified at 25k and 120k, including white/black backgrounds and 320px/480px layouts
- verified PNG exports with and without the legend and real Qt mouse dragging away from the Surface 1 menu
- confirmed opacity and legend changes do not invoke `/api/esp`, the extrema worker, or `addIsosurface()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live electrostatic potential (ESP) visualization for supported non-periodic sessions, including ESP surface rendering, layer activation, and persisted ESP analysis settings.
  * Added worker-powered ESP extrema detection with interactive minima/maxima markers and energy labels.
  * Added ESP visualization scaling, including a “Trans flag” gradient option and symmetric range estimation.
* **UI Improvements**
  * Expanded Tools with an ESP submenu (toggle surface, toggle extrema, adjust ESP surface opacity) and improved atom interaction/modifier behavior.
* **Documentation**
  * Updated the README with ESP availability rules and live ESP session details.
* **Tests**
  * Added unit tests covering ESP scaling/interpolation, extrema geometry & filtering, and caching/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->