### PR TITLE
Ensure Qt window close releases the Multiwfn backend

### DIFF
--- a/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
+++ b/frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
@@ -435,6 +435,7 @@ class MultiwfnQtGui(QMainWindow):
         self.profile_reported = False
         self.manifest_path = manifest_path.resolve()
         self.session_dir = self.manifest_path.parent
+        self.backend_return_signaled = False
         cleanup_session_files(self.session_dir, startup=True)
         self.frontend_dir = frontend_dir.resolve() if frontend_dir else None
         self.manifest = load_json(self.manifest_path)
@@ -450,6 +451,11 @@ class MultiwfnQtGui(QMainWindow):
             pass
         except OSError:
             pass
+
+        application = QApplication.instance()
+        if application is not None:
+            application.lastWindowClosed.connect(self._signal_backend_return)
+            application.aboutToQuit.connect(self._signal_backend_return)
 
         self.setWindowTitle("Multiwfn Qt GUI")
         self._configure_window_size()
@@ -1006,15 +1012,22 @@ class MultiwfnQtGui(QMainWindow):
         if (self.session_dir / "gui_stop.flag").is_file():
             self.close()
 
+    def _signal_backend_return(self) -> None:
+        if self.backend_return_signaled:
+            return
+        try:
+            (self.session_dir / "gui_stop.flag").write_text("return\n", encoding="utf-8")
+        except OSError as exc:
+            print(f"[multiwfn-qt] Could not notify backend of GUI close: {exc}", file=sys.stderr, flush=True)
+            return
+        self.backend_return_signaled = True
+
     def closeEvent(self, event) -> None:  # noqa: N802 - Qt API name
+        self._signal_backend_return()
         if self.stop_timer:
             self.stop_timer.stop()
         if self.profile_timer:
             self.profile_timer.stop()
-        try:
-            (self.session_dir / "gui_stop.flag").write_text("return\n", encoding="utf-8")
-        except OSError:
-            pass
         if self.server:
             self.server.stop()
         super().closeEvent(event)


### PR DESCRIPTION
## Summary

- notify the waiting Multiwfn process when the Qt window closes
- cover both `lastWindowClosed` and `aboutToQuit` application shutdown paths
- make the stop notification idempotent and report write failures to stderr

## Problem

The backend waits for `gui_stop.flag` while the 3Dmol Qt GUI is active. Relying only on `closeEvent` can miss application-level shutdown paths, leaving the backend waiting after the GUI has disappeared.

## Scope and current limitations

- This changes only the Qt/3Dmol GUI shell; it does not change the Multiwfn computational backend or `Multiwfn_noGUI`.
- Coordination still uses a file in the generated session directory. Per-process session-directory isolation and safe concurrent backends in the same working directory are outside this bugfix.
- If the session directory is no longer writable, the GUI reports the failure, but it cannot release the backend through the existing flag protocol.

## Validation

- `python3 -m py_compile frontend/qt-multiwfn-gui/qt_multiwfn_gui.py`
- `cmake --build build-qt-gui -j2`
- `bash tests/functional/run_3dmol_cube_unit_test.sh build-qt-gui/Multiwfn_QtGUI`