### PR TITLE
Protect Multiwfn computational source changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Keep the ownership policy itself under maintainer review.
+/.github/CODEOWNERS @Stardust0831
+/.github/workflows/core-source-guard.yml @Stardust0831
+
+# Official Multiwfn computational sources. GUI, build, packaging, test, and
+# documentation paths remain open to the normal contribution workflow.
+/*.f @Stardust0831
+/*.F @Stardust0831
+/*.f90 @Stardust0831
+/ext/** @Stardust0831
+/libreta_hybrid/** @Stardust0831

--- a/.github/workflows/core-source-guard.yml
+++ b/.github/workflows/core-source-guard.yml
@@ -1,0 +1,58 @@
+name: Protect Multiwfn core source
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  core-source-guard:
+    name: Core source guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      CORE_CHANGE_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'core-change-approved') }}
+
+    steps:
+      - name: Checkout pull request history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require explicit approval for computational core changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t protected_files < <(
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              awk '
+                /^[^/]+\.(f|F|f90)$/ { print; next }
+                /^(ext|libreta_hybrid)\// { print }
+              '
+          )
+
+          if [ "${#protected_files[@]}" -eq 0 ]; then
+            echo "No protected Multiwfn computational source files changed."
+            exit 0
+          fi
+
+          printf 'Protected Multiwfn source files changed:\n'
+          printf '  - %s\n' "${protected_files[@]}"
+
+          if [ "$CORE_CHANGE_APPROVED" = "true" ]; then
+            echo "Maintainer override label core-change-approved is present."
+            exit 0
+          fi
+
+          {
+            echo "::error title=Multiwfn computational core change requires approval::This PR changes protected official Multiwfn source. A maintainer must inspect the changes and add the core-change-approved label."
+            echo "Add the core-change-approved label only after checking numerical behavior and the reason the GUI/build adapter boundary cannot be preserved."
+          } >&2
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ For changes touching Multiwfn behavior, please describe:
 - Whether numerical output should change.
 - What official Multiwfn output or release package was used for comparison.
 
+Root-level Fortran sources and the `ext/` and `libreta_hybrid/` directories are
+treated as the official Multiwfn computational core. Pull requests that change
+these paths are blocked by the core-source guard until a maintainer has reviewed
+the reason and applied the `core-change-approved` label. This explicit approval
+also applies to official-source synchronization pull requests.
+
 For GUI work, prefer an adapter-style design. The long-term goal is frontend and
 backend separation: replace the legacy DISLIN GUI backend without rewriting
 computational modules. GUI changes should normally live in `frontend/`, `tools/`,


### PR DESCRIPTION
## Summary

- add CODEOWNERS coverage for the official Multiwfn computational source
- add a PR guard that requires the `core-change-approved` maintainer label when protected source files change
- document the explicit approval flow, including official-source synchronization PRs

## Protected paths

- root-level `*.f`, `*.F`, and `*.f90`
- `ext/`
- `libreta_hybrid/`
- the ownership policy and guard workflow themselves

GUI adapters, frontend code, CMake, CI, packaging, tests, and documentation remain in the normal contribution path.

## Follow-up after merge

Enable required Code Owner review and add `Core source guard` to the required status checks in the `main` ruleset.
