### PR TITLE
Improve generated file ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Build directories and CMake metadata
 build/
 /build-qt-gui/
 cmake-build-*/
@@ -8,6 +9,8 @@ compile_commands.json
 .build-env/
 perf-work/
 perf-results/
+
+# Compiled binaries and libraries
 Multiwfn
 Multiwfn_noGUI
 *.exe
@@ -21,6 +24,31 @@ Multiwfn_noGUI
 *.dylib
 *.so
 *.out
+
+# Python caches and local environments
 __pycache__/
 *.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.venv/
+venv/
+
+# Frontend dependencies and build output
+node_modules/
+dist/
+
+# Generated GUI session data
+multiwfn_3dmol_session/
+
+# OS and editor temporary files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# Generated documentation
 *.pdf


### PR DESCRIPTION
## Summary

- organize existing ignore rules by artifact type
- ignore Python caches and local environments plus frontend dependencies and build output
- ignore generated 3Dmol GUI session data and common OS/editor temporary files

## Verification

- `git diff --check`
- verified generated session, `node_modules`, `dist`, and cache paths are ignored
- verified renderer evaluation source, package metadata, and reference cube data remain visible to Git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ignored file patterns to cover build artifacts, compiled binaries, Python caches and environments, frontend dependencies, generated documentation, and temporary OS/editor files.
  * Added clearer section headings to improve organization of project exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->