### PR TITLE
Prevent concurrent MatterViz sessions from sharing a port

### DIFF
--- a/.github/workflows/matterviz-gui.yml
+++ b/.github/workflows/matterviz-gui.yml
@@ -105,6 +105,28 @@ jobs:
           test -x build-matterviz-gui/Multiwfn_MatterVizGUI
           test -f build-matterviz-gui/resources/frontend/matterviz-viewer/dist/index.html
 
+  windows-port-binding:
+    name: Windows MatterViz session isolation
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Test Windows-exclusive MatterViz service binding
+        run: >-
+          python -m unittest -v
+          tests/test_matterviz_server.py
+          tests/test_matterviz_webview.py
+
   package:
     name: Package MatterViz WebView (${{ matrix.platform }})
     if: github.event_name != 'pull_request'

--- a/tests/test_matterviz_server.py
+++ b/tests/test_matterviz_server.py
@@ -1,5 +1,6 @@
 import json
 import http.client
+import http.server
 from pathlib import Path
 import sys
 import tempfile
@@ -12,6 +13,75 @@ from unittest import mock
 TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 import multiwfn_matterviz_server as server  # noqa: E402
+
+
+class QuietHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, _format, *_args):
+        pass
+
+
+class PortBindingTests(unittest.TestCase):
+    def test_server_disables_live_address_reuse(self):
+        self.assertFalse(server.ThreadingHTTPServer.allow_reuse_address)
+        self.assertFalse(server.ThreadingHTTPServer.allow_reuse_port)
+
+    def test_busy_preferred_port_falls_back_to_an_os_assigned_port(self):
+        first = server.ThreadingHTTPServer(("127.0.0.1", 0), QuietHandler)
+        second = None
+        try:
+            preferred = int(first.server_address[1])
+            second = server.bind_http_server("127.0.0.1", preferred, QuietHandler)
+            self.assertNotEqual(int(second.server_address[1]), preferred)
+        finally:
+            if second is not None:
+                second.server_close()
+            first.server_close()
+
+    def test_concurrent_services_keep_their_session_manifests_isolated(self):
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            servers = []
+            threads = []
+            try:
+                for marker in ("older", "newer"):
+                    frontend = root / f"frontend-{marker}"
+                    session = root / f"session-{marker}"
+                    frontend.mkdir()
+                    session.mkdir()
+                    manifest = session / "manifest.json"
+                    manifest.write_text(json.dumps({"marker": marker}), encoding="utf-8")
+                    handler = server.make_handler(frontend, session, manifest)
+                    preferred = int(servers[0].server_address[1]) if servers else 0
+                    httpd = server.bind_http_server("127.0.0.1", preferred, handler)
+                    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+                    thread.start()
+                    servers.append(httpd)
+                    threads.append(thread)
+
+                self.assertNotEqual(servers[0].server_address[1], servers[1].server_address[1])
+                for marker, httpd in zip(("older", "newer"), servers, strict=True):
+                    connection = http.client.HTTPConnection(*httpd.server_address, timeout=2)
+                    connection.request("GET", "/session/manifest.json")
+                    response = connection.getresponse()
+                    payload = json.loads(response.read())
+                    connection.close()
+                    self.assertEqual(response.status, 200)
+                    self.assertEqual(payload, {"marker": marker})
+            finally:
+                for httpd in servers:
+                    httpd.shutdown()
+                    httpd.server_close()
+                for thread in threads:
+                    thread.join(timeout=2)
+
+    @unittest.skipUnless(hasattr(server.socket, "SO_EXCLUSIVEADDRUSE"), "Windows socket option")
+    def test_windows_server_uses_exclusive_address_binding(self):
+        httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), QuietHandler)
+        try:
+            value = httpd.socket.getsockopt(server.socket.SOL_SOCKET, server.socket.SO_EXCLUSIVEADDRUSE)
+            self.assertEqual(value, 1)
+        finally:
+            httpd.server_close()
 
 
 class OrbitalRequestTests(unittest.TestCase):

--- a/tests/test_matterviz_webview.py
+++ b/tests/test_matterviz_webview.py
@@ -205,7 +205,7 @@ class MatterVizWebViewTests(unittest.TestCase):
         )
         self.assertEqual(result, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(received[adapter.STOP_FILE_ENV], str(self.session / "gui_stop.flag"))
+        self.assertEqual(received[adapter.STOP_FILE_ENV], str(self.session.resolve() / "gui_stop.flag"))
 
     def test_service_is_running_before_startup_handshake(self):
         server = BlockingServer()

--- a/tools/multiwfn_matterviz_server.py
+++ b/tools/multiwfn_matterviz_server.py
@@ -53,19 +53,6 @@ class OrbitalRequest:
     isovalue: float
 
 
-def find_free_port(host: str, preferred: int) -> int:
-    if preferred > 0:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-            try:
-                probe.bind((host, preferred))
-                return preferred
-            except OSError:
-                pass
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind((host, 0))
-        return int(probe.getsockname()[1])
-
-
 def send_file(handler: http.server.BaseHTTPRequestHandler, path: Path) -> None:
     if not path.is_file():
         handler.send_error(404, "File not found")
@@ -379,6 +366,26 @@ def try_open_url(url: str) -> bool:
 
 class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     daemon_threads = True
+    allow_reuse_address = False
+    allow_reuse_port = False
+
+    def server_bind(self) -> None:
+        # On Windows SO_REUSEADDR permits multiple live servers to bind the
+        # same address. A later WebView can then reach an older session even
+        # though both launchers report the same URL.
+        if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        super().server_bind()
+
+
+def bind_http_server(host: str, preferred_port: int, handler):
+    """Bind once, falling back to an OS-assigned port when preferred is busy."""
+    try:
+        return ThreadingHTTPServer((host, preferred_port), handler)
+    except OSError:
+        if preferred_port == 0:
+            raise
+        return ThreadingHTTPServer((host, 0), handler)
 
 
 def make_handler(frontend_dir: Path, session_dir: Path, manifest: Path, state: Path | None = None):
@@ -508,9 +515,13 @@ def main() -> int:
         print(f"Workbench state not found: {state}", file=sys.stderr)
         return 2
 
-    port = find_free_port(args.host, args.port)
     handler = make_handler(frontend_dir, session_dir, manifest, state)
-    server = ThreadingHTTPServer((args.host, port), handler)
+    try:
+        server = bind_http_server(args.host, args.port, handler)
+    except OSError as exc:
+        print(f"Could not bind MatterViz GUI service: {exc}", file=sys.stderr)
+        return 2
+    port = int(server.server_address[1])
     url = build_workbench_url(args.host, port, state=state)
 
     print(f"Multiwfn MatterViz GUI service: {url}")

--- a/tools/multiwfn_matterviz_webview.py
+++ b/tools/multiwfn_matterviz_webview.py
@@ -215,12 +215,9 @@ def main() -> int:
         web.cleanup_session_files(session, startup=True)
         handler = web.make_handler(frontend, session, manifest, state)
         try:
-            server = web.ThreadingHTTPServer((args.host, args.port), handler)
-        except OSError:
-            try:
-                server = web.ThreadingHTTPServer((args.host, 0), handler)
-            except OSError as second_error:
-                return failure(f"Could not bind MatterViz WebView service: {second_error}")
+            server = web.bind_http_server(args.host, args.port, handler)
+        except OSError as bind_error:
+            return failure(f"Could not bind MatterViz WebView service: {bind_error}")
 
         port = int(server.server_address[1])
         url = web.build_workbench_url(args.host, port, state=state)


### PR DESCRIPTION
## Root cause

Preview 2 and Preview 3 could remain alive simultaneously on Windows and both report `127.0.0.1:8765`. Python's Windows `SO_REUSEADDR` behavior allowed the newer service to bind the same address, so its WebView could reach the older Preview 2 MOL2 session even though Preview 3 had generated a valid native `structure.json`.

## Fix

- disable live address/port reuse for the MatterViz HTTP server
- set Windows `SO_EXCLUSIVEADDRUSE` before binding
- atomically bind the preferred port, falling back to an OS-assigned port when occupied
- use the same binding helper for browser and WebView launch paths
- add concurrent-session manifest isolation tests and a native Windows PR check

No frontend, GUI/session protocol, or Multiwfn calculation-core behavior changes.

## Verification

- Linux: 43 Python tests passed; one Windows-only assertion skipped
- native Windows Python 3.13: 31 server/WebView tests passed, including exclusive binding and concurrent session isolation
- Python compilation, Actionlint and `git diff --check`
- two high-level read-only reviews found no remaining blocker/high/medium issue
