### PR TITLE
Harden MatterViz runtime startup and control transport

### DIFF
--- a/frontend/matterviz-desktop/src/control_transport.rs
+++ b/frontend/matterviz-desktop/src/control_transport.rs
@@ -21,7 +21,6 @@ pub struct ControlTransportConfig {
 #[derive(Debug)]
 pub enum ControlTransportError {
     InvalidConfig(&'static str),
-    InvalidHandle(&'static str),
     Io(io::Error),
     Codec(ControlError),
     Closed,
@@ -32,7 +31,6 @@ impl fmt::Display for ControlTransportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidConfig(message) => f.write_str(message),
-            Self::InvalidHandle(message) => f.write_str(message),
             Self::Io(error) => write!(f, "control pipe I/O failed: {error}"),
             Self::Codec(error) => write!(f, "invalid control frame: {error}"),
             Self::Closed => f.write_str("control transport is closed"),
@@ -214,26 +212,15 @@ fn read_exact_timeout(
 #[cfg(unix)]
 mod platform {
     use super::*;
+    use crate::inherited_pipe;
     use std::fs::File;
-    use std::os::fd::{FromRawFd, RawFd};
 
     pub struct PipeReader(File);
     pub struct PipeWriter(File);
 
     impl PipeReader {
         pub fn adopt(raw: u64) -> Result<Self, ControlTransportError> {
-            let fd = i32::try_from(raw).map_err(|_| {
-                ControlTransportError::InvalidHandle(
-                    "control read pipe is not a POSIX file descriptor",
-                )
-            })?;
-            if fd < 0 {
-                return Err(ControlTransportError::InvalidHandle(
-                    "control read pipe is invalid",
-                ));
-            }
-            // SAFETY: the launcher transfers ownership of this inherited descriptor.
-            Ok(Self(unsafe { File::from_raw_fd(fd as RawFd) }))
+            Ok(Self(inherited_pipe::adopt(raw)?))
         }
 
         pub(super) fn read_until(
@@ -277,18 +264,7 @@ mod platform {
 
     impl PipeWriter {
         pub fn adopt(raw: u64) -> Result<Self, ControlTransportError> {
-            let fd = i32::try_from(raw).map_err(|_| {
-                ControlTransportError::InvalidHandle(
-                    "control write pipe is not a POSIX file descriptor",
-                )
-            })?;
-            if fd < 0 {
-                return Err(ControlTransportError::InvalidHandle(
-                    "control write pipe is invalid",
-                ));
-            }
-            // SAFETY: the launcher transfers ownership of this inherited descriptor.
-            Ok(Self(unsafe { File::from_raw_fd(fd as RawFd) }))
+            Ok(Self(inherited_pipe::adopt(raw)?))
         }
     }
 
@@ -310,27 +286,15 @@ mod platform {
 #[cfg(windows)]
 mod platform {
     use super::*;
+    use crate::inherited_pipe;
     use std::fs::File;
-    use std::os::windows::io::FromRawHandle;
 
     pub struct PipeReader(File);
     pub struct PipeWriter(File);
 
-    fn handle(
-        raw: u64,
-        label: &'static str,
-    ) -> Result<*mut std::ffi::c_void, ControlTransportError> {
-        if raw == 0 || raw == u64::MAX {
-            return Err(ControlTransportError::InvalidHandle(label));
-        }
-        Ok(raw as usize as *mut std::ffi::c_void)
-    }
-
     impl PipeReader {
         pub fn adopt(raw: u64) -> Result<Self, ControlTransportError> {
-            let handle = handle(raw, "control read pipe is invalid")?;
-            // SAFETY: the launcher transfers ownership of this inherited handle.
-            Ok(Self(unsafe { File::from_raw_handle(handle) }))
+            Ok(Self(inherited_pipe::adopt(raw)?))
         }
 
         pub(super) fn read_until(
@@ -380,9 +344,7 @@ mod platform {
 
     impl PipeWriter {
         pub fn adopt(raw: u64) -> Result<Self, ControlTransportError> {
-            let handle = handle(raw, "control write pipe is invalid")?;
-            // SAFETY: the launcher transfers ownership of this inherited handle.
-            Ok(Self(unsafe { File::from_raw_handle(handle) }))
+            Ok(Self(inherited_pipe::adopt(raw)?))
         }
     }
 
@@ -430,6 +392,43 @@ mod tests {
         let mut fds = [0; 2];
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
         (fds[0], fds[1])
+    }
+
+    #[cfg(unix)]
+    fn clear_close_on_exec(fd: i32) {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_eq!(
+            unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) },
+            0
+        );
+    }
+
+    #[cfg(unix)]
+    fn assert_close_on_exec(fd: i32) {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adopted_control_descriptors_are_close_on_exec() {
+        let (read_in, write_in) = pipe();
+        let (read_out, write_out) = pipe();
+        let _input = unsafe { std::fs::File::from_raw_fd(write_in) };
+        let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
+        clear_close_on_exec(read_in);
+        clear_close_on_exec(write_out);
+
+        let _transport = ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: read_in as u64,
+            write_pipe: write_out as u64,
+        })
+        .unwrap();
+
+        assert_close_on_exec(read_in);
+        assert_close_on_exec(write_out);
     }
 
     #[cfg(unix)]

--- a/frontend/matterviz-desktop/src/control_transport.rs
+++ b/frontend/matterviz-desktop/src/control_transport.rs
@@ -149,6 +149,34 @@ impl ControlTransport {
         Ok(decode_frame(&frame)?)
     }
 
+    /// Wait up to `start_timeout` for a frame to begin, then require the complete
+    /// frame to arrive within `completion_timeout` of its first byte.
+    pub fn read_frame_startup(
+        &mut self,
+        start_timeout: Duration,
+        completion_timeout: Duration,
+    ) -> Result<ControlFrame, ControlTransportError> {
+        let reader = self.reader.as_mut().ok_or(ControlTransportError::Closed)?;
+        let start_deadline = Instant::now()
+            .checked_add(start_timeout)
+            .ok_or(ControlTransportError::Timeout)?;
+        let mut header = [0_u8; HEADER_BYTES];
+        read_exact_timeout(reader, &mut header[..1], start_deadline)?;
+
+        let completion_deadline = Instant::now()
+            .checked_add(completion_timeout)
+            .ok_or(ControlTransportError::Timeout)?;
+        read_exact_timeout(reader, &mut header[1..], completion_deadline)?;
+        let parsed = decode_header(&header)?;
+        let total = checked_frame_len(parsed.body_bytes)?;
+        let mut frame = vec![0_u8; total];
+        frame[..HEADER_BYTES].copy_from_slice(&header);
+        if total > HEADER_BYTES {
+            read_exact_timeout(reader, &mut frame[HEADER_BYTES..], completion_deadline)?;
+        }
+        Ok(decode_frame(&frame)?)
+    }
+
     pub fn close(&mut self) {
         self.reader.take();
         if let Ok(mut writer) = self.writer.lock() {
@@ -581,6 +609,32 @@ mod tests {
             Err(ControlTransportError::Timeout)
         ));
         assert!(started.elapsed() < Duration::from_secs(1));
+        writer.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_read_uses_a_separate_completion_deadline() {
+        let (read_in, write_in) = pipe();
+        let (read_out, write_out) = pipe();
+        let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
+        let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
+        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: read_in as u64,
+            write_pipe: write_out as u64,
+        })
+        .unwrap();
+        let hello = encode_frame(MessageType::Hello, 0, None).unwrap();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(40));
+            input.write_all(&hello[..1]).unwrap();
+            std::thread::sleep(Duration::from_millis(40));
+            let _ = input.write_all(&hello[1..]);
+        });
+        assert!(matches!(
+            transport.read_frame_startup(Duration::from_millis(100), Duration::from_millis(20)),
+            Err(ControlTransportError::Timeout)
+        ));
         writer.join().unwrap();
     }
 }

--- a/frontend/matterviz-desktop/src/control_transport.rs
+++ b/frontend/matterviz-desktop/src/control_transport.rs
@@ -54,7 +54,7 @@ impl From<ControlError> for ControlTransportError {
 }
 
 pub struct ControlTransport {
-    reader: Option<platform::PipeReader>,
+    reader: Mutex<Option<platform::PipeReader>>,
     writer: Mutex<Option<platform::PipeWriter>>,
 }
 
@@ -68,7 +68,7 @@ impl ControlTransport {
         let reader = platform::PipeReader::adopt(config.read_pipe)?;
         let writer = platform::PipeWriter::adopt(config.write_pipe)?;
         Ok(Self {
-            reader: Some(reader),
+            reader: Mutex::new(Some(reader)),
             writer: Mutex::new(Some(writer)),
         })
     }
@@ -114,8 +114,12 @@ impl ControlTransport {
     }
 
     #[cfg(test)]
-    pub fn read_frame(&mut self) -> Result<ControlFrame, ControlTransportError> {
-        let reader = self.reader.as_mut().ok_or(ControlTransportError::Closed)?;
+    pub fn read_frame(&self) -> Result<ControlFrame, ControlTransportError> {
+        let mut guard = self
+            .reader
+            .lock()
+            .map_err(|_| ControlTransportError::Closed)?;
+        let reader = guard.as_mut().ok_or(ControlTransportError::Closed)?;
         let mut header = [0_u8; HEADER_BYTES];
         read_exact(reader, &mut header)?;
         let parsed = decode_header(&header)?;
@@ -130,10 +134,14 @@ impl ControlTransport {
 
     /// Read one complete frame, including its header and body, before `timeout` expires.
     pub fn read_frame_timeout(
-        &mut self,
+        &self,
         timeout: Duration,
     ) -> Result<ControlFrame, ControlTransportError> {
-        let reader = self.reader.as_mut().ok_or(ControlTransportError::Closed)?;
+        let mut guard = self
+            .reader
+            .lock()
+            .map_err(|_| ControlTransportError::Closed)?;
+        let reader = guard.as_mut().ok_or(ControlTransportError::Closed)?;
         let deadline = Instant::now()
             .checked_add(timeout)
             .ok_or(ControlTransportError::Timeout)?;
@@ -152,11 +160,15 @@ impl ControlTransport {
     /// Wait up to `start_timeout` for a frame to begin, then require the complete
     /// frame to arrive within `completion_timeout` of its first byte.
     pub fn read_frame_startup(
-        &mut self,
+        &self,
         start_timeout: Duration,
         completion_timeout: Duration,
     ) -> Result<ControlFrame, ControlTransportError> {
-        let reader = self.reader.as_mut().ok_or(ControlTransportError::Closed)?;
+        let mut guard = self
+            .reader
+            .lock()
+            .map_err(|_| ControlTransportError::Closed)?;
+        let reader = guard.as_mut().ok_or(ControlTransportError::Closed)?;
         let start_deadline = Instant::now()
             .checked_add(start_timeout)
             .ok_or(ControlTransportError::Timeout)?;
@@ -177,8 +189,10 @@ impl ControlTransport {
         Ok(decode_frame(&frame)?)
     }
 
-    pub fn close(&mut self) {
-        self.reader.take();
+    pub fn close(&self) {
+        if let Ok(mut reader) = self.reader.lock() {
+            reader.take();
+        }
         if let Ok(mut writer) = self.writer.lock() {
             writer.take();
         }
@@ -466,7 +480,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let mut output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -495,7 +509,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let _input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -515,7 +529,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -545,7 +559,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -578,7 +592,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -593,7 +607,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })
@@ -619,7 +633,7 @@ mod tests {
         let (read_out, write_out) = pipe();
         let mut input = unsafe { std::fs::File::from_raw_fd(write_in) };
         let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
-        let mut transport = ControlTransport::adopt(ControlTransportConfig {
+        let transport = ControlTransport::adopt(ControlTransportConfig {
             read_pipe: read_in as u64,
             write_pipe: write_out as u64,
         })

--- a/frontend/matterviz-desktop/src/control_transport.rs
+++ b/frontend/matterviz-desktop/src/control_transport.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -25,6 +26,7 @@ pub enum ControlTransportError {
     Codec(ControlError),
     Closed,
     Timeout,
+    Cancelled,
 }
 
 impl fmt::Display for ControlTransportError {
@@ -35,6 +37,7 @@ impl fmt::Display for ControlTransportError {
             Self::Codec(error) => write!(f, "invalid control frame: {error}"),
             Self::Closed => f.write_str("control transport is closed"),
             Self::Timeout => f.write_str("control transport read timed out"),
+            Self::Cancelled => f.write_str("control transport read cancelled"),
         }
     }
 }
@@ -146,13 +149,13 @@ impl ControlTransport {
             .checked_add(timeout)
             .ok_or(ControlTransportError::Timeout)?;
         let mut header = [0_u8; HEADER_BYTES];
-        read_exact_timeout(reader, &mut header, deadline)?;
+        read_exact_timeout(reader, &mut header, deadline, None)?;
         let parsed = decode_header(&header)?;
         let total = checked_frame_len(parsed.body_bytes)?;
         let mut frame = vec![0_u8; total];
         frame[..HEADER_BYTES].copy_from_slice(&header);
         if total > HEADER_BYTES {
-            read_exact_timeout(reader, &mut frame[HEADER_BYTES..], deadline)?;
+            read_exact_timeout(reader, &mut frame[HEADER_BYTES..], deadline, None)?;
         }
         Ok(decode_frame(&frame)?)
     }
@@ -163,6 +166,7 @@ impl ControlTransport {
         &self,
         start_timeout: Duration,
         completion_timeout: Duration,
+        stop: &AtomicBool,
     ) -> Result<ControlFrame, ControlTransportError> {
         let mut guard = self
             .reader
@@ -173,18 +177,26 @@ impl ControlTransport {
             .checked_add(start_timeout)
             .ok_or(ControlTransportError::Timeout)?;
         let mut header = [0_u8; HEADER_BYTES];
-        read_exact_timeout(reader, &mut header[..1], start_deadline)?;
+        read_exact_timeout(reader, &mut header[..1], start_deadline, Some(stop))?;
 
         let completion_deadline = Instant::now()
             .checked_add(completion_timeout)
             .ok_or(ControlTransportError::Timeout)?;
-        read_exact_timeout(reader, &mut header[1..], completion_deadline)?;
+        read_exact_timeout(reader, &mut header[1..], completion_deadline, Some(stop))?;
         let parsed = decode_header(&header)?;
         let total = checked_frame_len(parsed.body_bytes)?;
         let mut frame = vec![0_u8; total];
         frame[..HEADER_BYTES].copy_from_slice(&header);
         if total > HEADER_BYTES {
-            read_exact_timeout(reader, &mut frame[HEADER_BYTES..], completion_deadline)?;
+            read_exact_timeout(
+                reader,
+                &mut frame[HEADER_BYTES..],
+                completion_deadline,
+                Some(stop),
+            )?;
+        }
+        if stop.load(Ordering::Acquire) {
+            return Err(ControlTransportError::Cancelled);
         }
         Ok(decode_frame(&frame)?)
     }
@@ -228,18 +240,39 @@ fn read_exact_timeout(
     reader: &mut platform::PipeReader,
     bytes: &mut [u8],
     deadline: Instant,
+    stop: Option<&AtomicBool>,
 ) -> Result<(), ControlTransportError> {
+    const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(50);
     let mut offset = 0;
     while offset < bytes.len() {
-        let count = reader
-            .read_until(deadline, &mut bytes[offset..])
-            .map_err(|error| {
-                if error.kind() == io::ErrorKind::TimedOut {
-                    ControlTransportError::Timeout
-                } else {
-                    error.into()
-                }
-            })?;
+        if stop.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            return Err(ControlTransportError::Cancelled);
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(ControlTransportError::Timeout);
+        }
+        let read_deadline = if stop.is_some() {
+            now.checked_add(CANCELLATION_POLL_INTERVAL)
+                .unwrap_or(deadline)
+                .min(deadline)
+        } else {
+            deadline
+        };
+        let count = match reader.read_until(read_deadline, &mut bytes[offset..]) {
+            Ok(count) => count,
+            Err(error)
+                if error.kind() == io::ErrorKind::TimedOut
+                    && stop.is_some()
+                    && Instant::now() < deadline =>
+            {
+                continue
+            }
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {
+                return Err(ControlTransportError::Timeout)
+            }
+            Err(error) => return Err(error.into()),
+        };
         if count == 0 {
             return Err(ControlTransportError::Io(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
@@ -645,10 +678,43 @@ mod tests {
             std::thread::sleep(Duration::from_millis(40));
             let _ = input.write_all(&hello[1..]);
         });
+        let stop = AtomicBool::new(false);
         assert!(matches!(
-            transport.read_frame_startup(Duration::from_millis(100), Duration::from_millis(20)),
+            transport.read_frame_startup(
+                Duration::from_millis(100),
+                Duration::from_millis(20),
+                &stop,
+            ),
             Err(ControlTransportError::Timeout)
         ));
         writer.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_read_observes_cancellation_before_its_deadline() {
+        let (read_in, write_in) = pipe();
+        let (read_out, write_out) = pipe();
+        let _input = unsafe { std::fs::File::from_raw_fd(write_in) };
+        let _output = unsafe { std::fs::File::from_raw_fd(read_out) };
+        let transport = ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: read_in as u64,
+            write_pipe: write_out as u64,
+        })
+        .unwrap();
+        let stop = AtomicBool::new(false);
+        let started = Instant::now();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                std::thread::sleep(Duration::from_millis(25));
+                stop.store(true, Ordering::Release);
+            });
+            assert!(matches!(
+                transport
+                    .read_frame_startup(Duration::from_secs(5), Duration::from_secs(5), &stop,),
+                Err(ControlTransportError::Cancelled)
+            ));
+        });
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 }

--- a/frontend/matterviz-desktop/src/inherited_pipe.rs
+++ b/frontend/matterviz-desktop/src/inherited_pipe.rs
@@ -1,0 +1,82 @@
+//! Ownership boundary for pipe endpoints inherited from the Multiwfn launcher.
+
+use std::fs::File;
+use std::io;
+
+#[cfg(unix)]
+pub fn adopt(raw: u64) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+    let fd = RawFd::try_from(raw).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "inherited pipe descriptor is too large",
+        )
+    })?;
+    // SAFETY: the launcher transfers ownership of this inherited descriptor.
+    let file = unsafe { File::from_raw_fd(fd) };
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+    if flags < 0
+        || unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub fn adopt(raw: u64) -> io::Result<File> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
+    use windows_sys::Win32::Foundation::{SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT};
+
+    let raw = usize::try_from(raw).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "inherited pipe handle is too large",
+        )
+    })?;
+    if raw == 0 || raw == usize::MAX {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "inherited pipe handle is invalid",
+        ));
+    }
+    // SAFETY: the launcher transfers ownership of this inherited handle.
+    let file = unsafe { File::from_raw_handle(raw as RawHandle) };
+    let changed =
+        unsafe { SetHandleInformation(file.as_raw_handle() as HANDLE, HANDLE_FLAG_INHERIT, 0) };
+    if changed == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+    use std::os::windows::io::{FromRawHandle, RawHandle};
+    use windows_sys::Win32::Foundation::{
+        GetHandleInformation, SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT,
+    };
+    use windows_sys::Win32::System::Pipes::CreatePipe;
+
+    #[test]
+    fn adopted_handle_is_not_inheritable() {
+        let mut read: HANDLE = std::ptr::null_mut();
+        let mut write: HANDLE = std::ptr::null_mut();
+        assert_ne!(
+            unsafe { CreatePipe(&mut read, &mut write, std::ptr::null(), 0) },
+            0
+        );
+        let _write = unsafe { File::from_raw_handle(write as RawHandle) };
+        assert_ne!(
+            unsafe { SetHandleInformation(read, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) },
+            0
+        );
+
+        let _read = adopt(read as usize as u64).unwrap();
+        let mut flags = 0_u32;
+        assert_ne!(unsafe { GetHandleInformation(read, &mut flags) }, 0);
+        assert_eq!(flags & HANDLE_FLAG_INHERIT, 0);
+    }
+}

--- a/frontend/matterviz-desktop/src/main.rs
+++ b/frontend/matterviz-desktop/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod control_protocol;
 mod control_transport;
 mod file_dialog;
+mod inherited_pipe;
 mod lifecycle;
 mod memory_budget;
 mod picker_protocol;

--- a/frontend/matterviz-desktop/src/main.rs
+++ b/frontend/matterviz-desktop/src/main.rs
@@ -9,6 +9,7 @@ mod memory_budget;
 mod picker_protocol;
 mod service;
 mod session_data;
+mod shutdown;
 mod stream_broker;
 mod transport;
 pub mod volume_protocol;

--- a/frontend/matterviz-desktop/src/main.rs
+++ b/frontend/matterviz-desktop/src/main.rs
@@ -147,6 +147,8 @@ fn run_tauri(url: String, service: Option<Arc<HttpService>>, timeout: Duration) 
     let window_service = service.clone();
     let cleanup_service = service.clone();
     let stop_service = service.clone();
+    let ready_service = service.clone();
+    let navigation_reports_ready = service.is_none();
     let result = tauri::Builder::default()
         .setup(move |app| {
             let callback_status = setup_status.clone();
@@ -156,7 +158,9 @@ fn run_tauri(url: String, service: Option<Arc<HttpService>>, timeout: Duration) 
                     .inner_size(1400.0, 900.0)
                     .resizable(true)
                     .on_page_load(move |_window, payload| {
-                        if matches!(payload.event(), PageLoadEvent::Finished) {
+                        if navigation_reports_ready
+                            && matches!(payload.event(), PageLoadEvent::Finished)
+                        {
                             callback_status.ready();
                         }
                     })
@@ -165,6 +169,18 @@ fn run_tauri(url: String, service: Option<Arc<HttpService>>, timeout: Duration) 
                 let message = format!("could not create MatterViz window: {error}");
                 setup_status.error(&message);
                 return Err(std::io::Error::other(message).into());
+            }
+            if let Some(service) = ready_service.clone() {
+                let ready_status = setup_status.clone();
+                thread::spawn(move || {
+                    while !service.is_shutdown() {
+                        if service.frontend_ready() {
+                            ready_status.ready();
+                            break;
+                        }
+                        thread::sleep(Duration::from_millis(20));
+                    }
+                });
             }
             lifecycle::spawn_startup_timeout(app.handle().clone(), setup_status.clone(), timeout);
             if let Some(service) = stop_service.clone() {

--- a/frontend/matterviz-desktop/src/memory_budget.rs
+++ b/frontend/matterviz-desktop/src/memory_budget.rs
@@ -422,11 +422,15 @@ fn macos_memory_snapshot(
 
 #[cfg(target_os = "macos")]
 fn macos_vm_page_counts() -> Result<(u64, u64), String> {
+    unsafe extern "C" {
+        fn mach_host_self() -> libc::mach_port_t;
+    }
+
     let mut statistics: libc::vm_statistics64_data_t = unsafe { std::mem::zeroed() };
     let mut count = libc::HOST_VM_INFO64_COUNT;
     let status = unsafe {
         libc::host_statistics64(
-            libc::mach_host_self(),
+            mach_host_self(),
             libc::HOST_VM_INFO64,
             (&mut statistics as *mut libc::vm_statistics64_data_t).cast::<libc::integer_t>(),
             &mut count,

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -55,6 +55,7 @@ pub struct HttpService {
     control_transport: Arc<Mutex<Option<ControlTransport>>>,
     session_data: Option<SessionData>,
     in_memory_session: bool,
+    frontend_ready: Arc<AtomicBool>,
     return_signaled: Arc<AtomicBool>,
     worker: Mutex<Option<thread::JoinHandle<()>>>,
 }
@@ -119,6 +120,13 @@ impl HttpService {
         if !frontend.is_dir() {
             return Err("frontend path is not a directory".to_owned());
         }
+        let entry_document = frontend.join("index.html");
+        if !entry_document.is_file() {
+            return Err("frontend entry document index.html was not found".to_owned());
+        }
+        fs::File::open(&entry_document).map_err(|error| {
+            format!("frontend entry document index.html is not readable: {error}")
+        })?;
         if (!in_memory_session && !session.is_dir())
             || manifest.as_ref().is_some_and(|path| !path.is_file())
             || state.as_ref().is_some_and(|path| !path.is_file())
@@ -147,6 +155,7 @@ impl HttpService {
         write!(query, "&cap={capability}").expect("write capability query");
         let authority = format!("{}:{}", format_host(&host), address.port());
         let stop = Arc::new(AtomicBool::new(false));
+        let frontend_ready = Arc::new(AtomicBool::new(false));
         let volume_store = Arc::new(VolumeStore::new());
         let stream_broker = Arc::new(VolumeStreamBroker::default());
         let streaming_volume_enabled = config.transport.is_some();
@@ -213,6 +222,7 @@ impl HttpService {
             control_transport: Arc::new(Mutex::new(control_transport)),
             session_data,
             in_memory_session,
+            frontend_ready,
             return_signaled: Arc::new(AtomicBool::new(false)),
             worker: Mutex::new(None),
         };
@@ -256,6 +266,7 @@ impl HttpService {
             orbital_count,
             control_transport: self.control_transport.clone(),
             in_memory_session: self.in_memory_session,
+            frontend_ready: self.frontend_ready.clone(),
             return_signaled: self.return_signaled.clone(),
         }
     }
@@ -264,6 +275,9 @@ impl HttpService {
     }
     pub fn session_path(&self) -> &Path {
         &self.session
+    }
+    pub fn frontend_ready(&self) -> bool {
+        self.frontend_ready.load(Ordering::Acquire)
     }
     pub fn uses_file_lifecycle(&self) -> bool {
         !self.in_memory_session
@@ -338,6 +352,7 @@ struct ServiceRunner {
     orbital_count: Option<i64>,
     control_transport: Arc<Mutex<Option<ControlTransport>>>,
     in_memory_session: bool,
+    frontend_ready: Arc<AtomicBool>,
     return_signaled: Arc<AtomicBool>,
 }
 impl ServiceRunner {
@@ -379,6 +394,7 @@ impl ServiceRunner {
             orbital_count: self.orbital_count,
             control_transport: self.control_transport.clone(),
             in_memory_session: self.in_memory_session,
+            frontend_ready: self.frontend_ready.clone(),
             return_signaled: self.return_signaled.clone(),
         }
     }
@@ -399,7 +415,7 @@ impl ServiceRunner {
         let mut parts = first.split_whitespace();
         let method = parts.next().unwrap_or("");
         let target = parts.next().unwrap_or("/");
-        if method != "GET" && method != "HEAD" {
+        if method != "GET" && method != "HEAD" && method != "POST" {
             respond(
                 &mut stream,
                 405,
@@ -456,6 +472,25 @@ impl ServiceRunner {
                 403,
                 method == "HEAD",
             );
+            return;
+        }
+        if path == "/api/ready" {
+            if method != "POST" {
+                respond(
+                    &mut stream,
+                    405,
+                    "text/plain",
+                    b"Method Not Allowed",
+                    method == "HEAD",
+                );
+                return;
+            }
+            self.frontend_ready.store(true, Ordering::Release);
+            respond_json(&mut stream, &json!({"ok": true}), 200, false);
+            return;
+        }
+        if method == "POST" {
+            respond(&mut stream, 405, "text/plain", b"Method Not Allowed", false);
             return;
         }
         if path == "/api/return" {
@@ -2069,6 +2104,84 @@ mod tests {
             "application/wasm"
         );
     }
+
+    #[test]
+    fn service_rejects_a_missing_frontend_entry_document() {
+        let root = fixture("missing-frontend-entry");
+        let frontend = root.join("frontend");
+        let session = root.join("session");
+        fs::create_dir_all(&frontend).unwrap();
+        fs::create_dir_all(&session).unwrap();
+        fs::write(session.join("manifest.json"), "{}").unwrap();
+
+        let result = HttpService::start(AppConfig {
+            frontend,
+            session,
+            manifest: None,
+            state: None,
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+            transport: None,
+        });
+        match result {
+            Err(error) => assert!(error.contains("index.html"), "{error}"),
+            Ok(service) => {
+                service.shutdown();
+                join_service(service);
+                panic!("service accepted a frontend directory without index.html");
+            }
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn service_requires_a_capability_authenticated_ready_post() {
+        let root = fixture("frontend-ready");
+        let frontend = root.join("frontend");
+        let session = root.join("session");
+        fs::create_dir_all(&frontend).unwrap();
+        fs::create_dir_all(&session).unwrap();
+        fs::write(frontend.join("index.html"), "MatterViz").unwrap();
+        fs::write(session.join("manifest.json"), "{}").unwrap();
+
+        let service = HttpService::start(AppConfig {
+            frontend,
+            session,
+            manifest: None,
+            state: None,
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+            transport: None,
+        })
+        .unwrap();
+        assert!(!service.frontend_ready());
+
+        let missing_capability = request(service.url(), "POST", "/api/ready");
+        assert!(missing_capability.starts_with("HTTP/1.1 403 Forbidden"));
+        let wrong_capability = request(service.url(), "POST", "/api/ready?cap=wrong");
+        assert!(wrong_capability.starts_with("HTTP/1.1 403 Forbidden"));
+        let wrong_method = request(
+            service.url(),
+            "GET",
+            &authorized_path(service.url(), "/api/ready"),
+        );
+        assert!(wrong_method.starts_with("HTTP/1.1 405 Method Not Allowed"));
+        assert!(!service.frontend_ready());
+
+        let ready = request(
+            service.url(),
+            "POST",
+            &authorized_path(service.url(), "/api/ready"),
+        );
+        assert!(ready.starts_with("HTTP/1.1 200 OK"));
+        assert!(ready.ends_with(r#"{"ok":true}"#));
+        assert!(service.frontend_ready());
+
+        service.shutdown();
+        join_service(service);
+        let _ = fs::remove_dir_all(root);
+    }
+
     #[test]
     fn safe_join_blocks_traversal() {
         let root = tempfile_dir();

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -532,7 +532,9 @@ impl ServiceRunner {
             return;
         }
         if let Some(value) = value {
-            let status = if path == "/api/orbital"
+            let status = if self.session_data.is_some() {
+                backend_response_status(&value)
+            } else if path == "/api/orbital"
                 && value
                     .get("message")
                     .and_then(Value::as_str)
@@ -971,10 +973,20 @@ fn request_control(
             {
                 Err("Mismatched Multiwfn control response".to_owned())
             } else {
-                frame
+                let result = frame
                     .body
                     .and_then(|body| body.get("result").cloned())
-                    .ok_or_else(|| "Malformed Multiwfn control response".to_owned())
+                    .ok_or_else(|| "Malformed Multiwfn control response".to_owned())?;
+                if result
+                    .as_object()
+                    .and_then(|object| object.get("ok"))
+                    .and_then(Value::as_bool)
+                    .is_none()
+                {
+                    Err("Malformed Multiwfn control response".to_owned())
+                } else {
+                    Ok(result)
+                }
             }
         });
     match result {
@@ -1312,7 +1324,8 @@ fn respond(stream: &mut TcpStream, status: u16, content_type: &str, body: &[u8],
 #[cfg(test)]
 mod tests {
     use super::{
-        content_type, decode_path, query_u64, request_control, safe_join, AppConfig, HttpService,
+        backend_response_status, content_type, decode_path, query_u64, request_control, safe_join,
+        AppConfig, HttpService,
     };
     use crate::control_protocol::{
         decode_frame, decode_header, encode_frame, MessageType, HEADER_BYTES,
@@ -1698,6 +1711,185 @@ mod tests {
         assert!(stop.load(Ordering::Acquire));
         assert!(control.lock().unwrap().is_none());
         assert_eq!(volumes.bytes(), 0);
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn control_result_requires_an_object_with_boolean_ok() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let cases = [
+            ("missing result", None, false),
+            ("null result", Some(serde_json::Value::Null), false),
+            ("string result", Some(serde_json::json!("ok")), false),
+            ("array result", Some(serde_json::json!([])), false),
+            ("number result", Some(serde_json::json!(1)), false),
+            ("missing ok", Some(serde_json::json!({})), false),
+            (
+                "non-boolean ok",
+                Some(serde_json::json!({"ok": "true"})),
+                false,
+            ),
+            (
+                "valid success",
+                Some(serde_json::json!({"ok": true, "value": 1.25})),
+                true,
+            ),
+            (
+                "valid failure",
+                Some(serde_json::json!({"ok": false, "message": "rejected"})),
+                true,
+            ),
+        ];
+
+        for (index, (name, result, valid)) in cases.into_iter().enumerate() {
+            let (mut request_read, request_write) = pipe_pair();
+            let (response_read, mut response_write) = pipe_pair();
+            let control = Arc::new(Mutex::new(Some(
+                crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+                    read_pipe: into_raw_pipe(response_read),
+                    write_pipe: into_raw_pipe(request_write),
+                })
+                .unwrap(),
+            )));
+            let request_id = 70 + index as u64;
+            let producer = std::thread::spawn(move || {
+                let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
+                assert_eq!(request.header.request_id, request_id);
+                let mut response = serde_json::json!({
+                    "format": "multiwfn-matterviz-control",
+                    "version": 1,
+                    "kind": "response",
+                    "request_id": request_id,
+                });
+                if let Some(result) = result {
+                    response["result"] = result;
+                }
+                let frame =
+                    encode_frame(MessageType::Response, request_id, Some(&response)).unwrap();
+                response_write.write_all(&frame).unwrap();
+            });
+            let stop = AtomicBool::new(false);
+            let volumes = crate::volume_store::VolumeStore::new();
+            volumes.insert(golden_frame()).unwrap();
+            let response = request_control(
+                &control,
+                &stop,
+                &volumes,
+                request_id,
+                "bond 1 2 mayer",
+                std::time::Duration::from_secs(1),
+            );
+            producer.join().unwrap();
+
+            if valid {
+                assert!(
+                    response
+                        .get("ok")
+                        .and_then(serde_json::Value::as_bool)
+                        .is_some(),
+                    "{name}"
+                );
+                assert!(!stop.load(Ordering::Acquire), "{name}");
+                assert!(control.lock().unwrap().is_some(), "{name}");
+                assert_ne!(volumes.bytes(), 0, "{name}");
+            } else {
+                assert_eq!(response["ok"], false, "{name}");
+                assert!(
+                    response["message"].as_str().unwrap().contains("Malformed"),
+                    "{name}"
+                );
+                assert_ne!(backend_response_status(&response), 200, "{name}");
+                assert!(stop.load(Ordering::Acquire), "{name}");
+                assert!(control.lock().unwrap().is_none(), "{name}");
+                assert_eq!(volumes.bytes(), 0, "{name}");
+            }
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn malformed_control_result_returns_http_error_and_stops_session() {
+        let root = fixture("malformed-control-result");
+        let frontend = root.join("frontend");
+        let session = root.join("session-must-not-exist");
+        fs::create_dir_all(&frontend).unwrap();
+        fs::write(frontend.join("index.html"), "MatterViz").unwrap();
+
+        let (mut request_read, request_write) = pipe_pair();
+        let (response_read, mut response_write) = pipe_pair();
+        let producer = std::thread::spawn(move || {
+            let hello = decode_frame(&read_control_frame(&mut request_read)).unwrap();
+            assert_eq!(hello.header.message_type, MessageType::Hello);
+            let session_init = serde_json::json!({
+                "format": "multiwfn-matterviz-control",
+                "version": 1,
+                "kind": "session_init",
+                "manifest": {
+                    "format": "multiwfn-matterviz-workbench",
+                    "version": 2,
+                    "structure": {"path": "structure.json", "format": "json"},
+                    "cubes": []
+                },
+                "structure": {"sites": [], "charge": 0, "properties": {"bonds": []}}
+            });
+            response_write
+                .write_all(&encode_frame(MessageType::SessionInit, 0, Some(&session_init)).unwrap())
+                .unwrap();
+
+            let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
+            assert_eq!(request.header.message_type, MessageType::Request);
+            let response = serde_json::json!({
+                "format": "multiwfn-matterviz-control",
+                "version": 1,
+                "kind": "response",
+                "request_id": request.header.request_id,
+                "result": null
+            });
+            response_write
+                .write_all(
+                    &encode_frame(
+                        MessageType::Response,
+                        request.header.request_id,
+                        Some(&response),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        });
+
+        let service = HttpService::start_with_control(
+            AppConfig {
+                frontend,
+                session,
+                manifest: None,
+                state: None,
+                host: "127.0.0.1".to_owned(),
+                port: 0,
+                transport: None,
+            },
+            Some(ControlTransportConfig {
+                read_pipe: into_raw_pipe(response_read),
+                write_pipe: into_raw_pipe(request_write),
+            }),
+        )
+        .unwrap();
+        service.insert_volume(golden_frame()).unwrap();
+        let response = request(
+            service.url(),
+            "GET",
+            &authorized_path(service.url(), "/api/bond?atom1=1&atom2=2&method=mayer"),
+        );
+
+        producer.join().unwrap();
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+        assert!(response.contains("Malformed Multiwfn control response"));
+        assert!(service.is_shutdown());
+        assert_eq!(service.volume_store.bytes(), 0);
+        assert_eq!(service.termination_exit_code(), 2);
+        join_service(service);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[cfg(any(unix, windows))]

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -248,6 +248,7 @@ impl HttpService {
                     .read_frame_startup(
                         session_bootstrap_wait_timeout(bootstrap_stage_timeout),
                         bootstrap_stage_timeout,
+                        shutdown.flag(),
                     )
                     .map_err(|error| format!("could not receive session bootstrap: {error}"))?;
                 let data = SessionData::from_frame(&frame)
@@ -442,6 +443,7 @@ impl ServiceRunner {
                 }
                 Err(_) => {
                     self.volume_store.clear();
+                    self.shutdown.request();
                     break;
                 }
             }
@@ -1608,6 +1610,62 @@ mod tests {
             assert!(!session.exists());
             let _ = fs::remove_dir_all(root);
         }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn volume_shutdown_cancels_session_bootstrap() {
+        let root = fixture("cancelled-bootstrap");
+        let frontend = root.join("frontend");
+        let session = root.join("session-must-not-exist");
+        fs::create_dir_all(&frontend).unwrap();
+        fs::write(frontend.join("index.html"), "MatterViz").unwrap();
+
+        let (volume_read, volume_write) = pipe_pair();
+        let (mut ack_read, ack_write) = pipe_pair();
+        let (mut hello_read, hello_write) = pipe_pair();
+        let (bootstrap_read, bootstrap_write) = pipe_pair();
+        let producer = std::thread::spawn(move || {
+            let hello = decode_frame(&read_control_frame(&mut hello_read)).unwrap();
+            assert_eq!(hello.header.message_type, MessageType::Hello);
+            let mut ready = [0_u8; PRELUDE_BYTES];
+            ack_read.read_exact(&mut ready).unwrap();
+            drop(volume_write);
+        });
+
+        let started = std::time::Instant::now();
+        let result = HttpService::start_with_control_stage_timeout(
+            AppConfig {
+                frontend,
+                session: session.clone(),
+                manifest: None,
+                state: None,
+                host: "127.0.0.1".to_owned(),
+                port: 0,
+                transport: Some(TransportConfig {
+                    volume_read_pipe: into_raw_pipe(volume_read),
+                    volume_ack_pipe: into_raw_pipe(ack_write),
+                }),
+            },
+            Some(ControlTransportConfig {
+                read_pipe: into_raw_pipe(bootstrap_read),
+                write_pipe: into_raw_pipe(hello_write),
+            }),
+            Duration::from_secs(5),
+        );
+        let Err(error) = result else {
+            panic!("bootstrap unexpectedly succeeded");
+        };
+        assert!(
+            error.contains("control transport read cancelled"),
+            "unexpected bootstrap error: {error}"
+        );
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        drop(bootstrap_write);
+        producer.join().unwrap();
+        assert!(!session.exists());
+        let _ = fs::remove_dir_all(root);
     }
 
     #[cfg(any(unix, windows))]

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -1382,6 +1382,7 @@ mod tests {
     use std::io::{ErrorKind, Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use url::Url;
 
@@ -1487,6 +1488,10 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn delayed_initial_volumes_complete_before_session_bootstrap() {
+        // One volume completes within a stage; two exceed one stage but fit the three-stage window.
+        const STAGE_TIMEOUT: Duration = Duration::from_secs(1);
+        const CHUNK_DELAY: Duration = Duration::from_millis(150);
+
         for volume_count in 1_u64..=2 {
             let root = fixture(&format!("delayed-bootstrap-{volume_count}"));
             let frontend = root.join("frontend");
@@ -1511,7 +1516,7 @@ mod tests {
                     let frame = encode_volume(&volume).unwrap();
                     let chunk_len = frame.len().div_ceil(4);
                     for chunk in frame.chunks(chunk_len) {
-                        std::thread::sleep(std::time::Duration::from_millis(45));
+                        std::thread::sleep(CHUNK_DELAY);
                         volume_write.write_all(chunk).unwrap();
                     }
                     let mut ack = [0_u8; ACK_HEADER_BYTES];
@@ -1555,7 +1560,7 @@ mod tests {
                     read_pipe: into_raw_pipe(bootstrap_read),
                     write_pipe: into_raw_pipe(hello_write),
                 }),
-                std::time::Duration::from_millis(300),
+                STAGE_TIMEOUT,
             )
             .unwrap();
             service.signal_return().unwrap();

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -14,6 +14,7 @@ use crate::control_protocol::MessageType;
 use crate::control_transport::{ControlTransport, ControlTransportConfig};
 use crate::memory_budget;
 use crate::session_data::SessionData;
+use crate::shutdown::ShutdownSignal;
 use crate::stream_broker::{StreamEvent, VolumeStreamBroker};
 use crate::transport::{TransportConfig, VolumeTransport};
 #[cfg(test)]
@@ -42,7 +43,7 @@ pub struct AppConfig {
 
 pub struct HttpService {
     session: PathBuf,
-    stop: Arc<AtomicBool>,
+    shutdown: ShutdownSignal,
     listener: TcpListener,
     url: String,
     backend_lock: Arc<Mutex<()>>,
@@ -52,12 +53,78 @@ pub struct HttpService {
     stream_broker: Arc<VolumeStreamBroker>,
     streaming_volume_enabled: bool,
     transport: Mutex<Option<VolumeTransport>>,
-    control_transport: Arc<Mutex<Option<Arc<ControlTransport>>>>,
+    control_session: Option<Arc<ControlSession>>,
     session_data: Option<SessionData>,
     in_memory_session: bool,
     frontend_ready: Arc<AtomicBool>,
     return_signaled: Arc<Mutex<bool>>,
     worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+struct ControlSession {
+    transport: Arc<Mutex<Option<Arc<ControlTransport>>>>,
+    shutdown: ShutdownSignal,
+    volume_store: Arc<VolumeStore>,
+}
+
+impl ControlSession {
+    fn new(
+        transport: ControlTransport,
+        shutdown: ShutdownSignal,
+        volume_store: Arc<VolumeStore>,
+    ) -> Self {
+        Self {
+            transport: Arc::new(Mutex::new(Some(Arc::new(transport)))),
+            shutdown,
+            volume_store,
+        }
+    }
+
+    fn is_available(&self) -> bool {
+        self.transport
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+    }
+
+    fn request(&self, request_id: u64, command: &str, timeout: Duration) -> Value {
+        request_control(
+            &self.transport,
+            &self.shutdown,
+            &self.volume_store,
+            request_id,
+            command,
+            timeout,
+        )
+    }
+
+    fn signal_return(&self) -> Result<(), String> {
+        let body = json!({
+            "format": "multiwfn-matterviz-control",
+            "version": 1,
+            "kind": "shutdown",
+        });
+        let transport = self
+            .transport
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .cloned();
+        let result = match transport {
+            Some(transport) => transport
+                .send_json(MessageType::Shutdown, 0, &body)
+                .map_err(|error| format!("could not signal Multiwfn Return: {error}")),
+            None => Err("Multiwfn control transport is unavailable".to_owned()),
+        };
+        if result.is_err() {
+            self.invalidate();
+        }
+        result
+    }
+
+    fn invalidate(&self) {
+        terminate_control_session(&self.transport, &self.shutdown, &self.volume_store);
+    }
 }
 
 impl HttpService {
@@ -154,7 +221,7 @@ impl HttpService {
         }
         write!(query, "&cap={capability}").expect("write capability query");
         let authority = format!("{}:{}", format_host(&host), address.port());
-        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = ShutdownSignal::new(address);
         let frontend_ready = Arc::new(AtomicBool::new(false));
         let volume_store = Arc::new(VolumeStore::new());
         let stream_broker = Arc::new(VolumeStreamBroker::default());
@@ -166,11 +233,11 @@ impl HttpService {
                     transport,
                     volume_store.clone(),
                     stream_broker.clone(),
-                    stop.clone(),
+                    shutdown.clone(),
                 )
             })
             .transpose()?;
-        let (control_transport, session_data) = control_config
+        let (control_session, session_data) = control_config
             .map(|config| {
                 let transport = ControlTransport::adopt(config)
                     .map_err(|error| format!("could not adopt control transport: {error}"))?;
@@ -189,7 +256,14 @@ impl HttpService {
             })
             .transpose()?
             .map_or((None, None), |(transport, data)| {
-                (Some(Arc::new(transport)), Some(data))
+                (
+                    Some(Arc::new(ControlSession::new(
+                        transport,
+                        shutdown.clone(),
+                        volume_store.clone(),
+                    ))),
+                    Some(data),
+                )
             });
         let has_state = state.is_some()
             || session_data
@@ -209,7 +283,7 @@ impl HttpService {
         );
         let service = Self {
             session,
-            stop,
+            shutdown,
             listener,
             url,
             backend_lock: Arc::new(Mutex::new(())),
@@ -219,7 +293,7 @@ impl HttpService {
             stream_broker,
             streaming_volume_enabled,
             transport: Mutex::new(transport),
-            control_transport: Arc::new(Mutex::new(control_transport)),
+            control_session,
             session_data,
             in_memory_session,
             frontend_ready,
@@ -255,7 +329,7 @@ impl HttpService {
             manifest,
             state,
             listener: self.listener.try_clone().expect("listener clone"),
-            stop: self.stop.clone(),
+            shutdown: self.shutdown.clone(),
             backend_lock: self.backend_lock.clone(),
             capability: self.capability.clone(),
             authority: self.authority.clone(),
@@ -264,7 +338,7 @@ impl HttpService {
             streaming_volume_enabled: self.streaming_volume_enabled,
             session_data: self.session_data.clone(),
             orbital_count,
-            control_transport: self.control_transport.clone(),
+            control_session: self.control_session.clone(),
             in_memory_session: self.in_memory_session,
             frontend_ready: self.frontend_ready.clone(),
             return_signaled: self.return_signaled.clone(),
@@ -283,7 +357,7 @@ impl HttpService {
         !self.in_memory_session
     }
     pub fn is_shutdown(&self) -> bool {
-        self.stop.load(Ordering::Acquire)
+        self.shutdown.is_requested()
     }
     pub fn termination_exit_code(&self) -> i32 {
         if self.in_memory_session
@@ -291,11 +365,10 @@ impl HttpService {
                 .return_signaled
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
-                || self
-                    .control_transport
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .is_none())
+                || !self
+                    .control_session
+                    .as_ref()
+                    .is_some_and(|session| session.is_available()))
         {
             2
         } else {
@@ -306,14 +379,10 @@ impl HttpService {
         let result = signal_return(
             self.in_memory_session,
             &self.return_signaled,
-            &self.control_transport,
+            self.control_session.as_deref(),
             &self.session,
         );
         self.volume_store.clear();
-        if result.is_err() && self.in_memory_session {
-            terminate_control_session(&self.control_transport, &self.stop, &self.volume_store);
-            wake_listener(&self.listener);
-        }
         result
     }
     #[cfg(test)]
@@ -325,8 +394,7 @@ impl HttpService {
     }
     pub fn shutdown(&self) {
         self.volume_store.clear();
-        self.stop.store(true, Ordering::Release);
-        wake_listener(&self.listener);
+        self.shutdown.request();
     }
     pub fn join(&self) {
         if let Some(worker) = self.worker.lock().expect("service worker lock").take() {
@@ -344,7 +412,7 @@ struct ServiceRunner {
     manifest: Option<PathBuf>,
     state: Option<PathBuf>,
     listener: TcpListener,
-    stop: Arc<AtomicBool>,
+    shutdown: ShutdownSignal,
     backend_lock: Arc<Mutex<()>>,
     capability: String,
     authority: String,
@@ -353,17 +421,17 @@ struct ServiceRunner {
     streaming_volume_enabled: bool,
     session_data: Option<SessionData>,
     orbital_count: Option<i64>,
-    control_transport: Arc<Mutex<Option<Arc<ControlTransport>>>>,
+    control_session: Option<Arc<ControlSession>>,
     in_memory_session: bool,
     frontend_ready: Arc<AtomicBool>,
     return_signaled: Arc<Mutex<bool>>,
 }
 impl ServiceRunner {
     fn run(self) {
-        while !self.stop.load(Ordering::Acquire) {
+        while !self.shutdown.is_requested() {
             match self.listener.accept() {
                 Ok((stream, _)) => {
-                    if self.stop.load(Ordering::Acquire) {
+                    if self.shutdown.is_requested() {
                         break;
                     }
                     let runner = self.clone_for_request();
@@ -386,7 +454,7 @@ impl ServiceRunner {
             manifest: self.manifest.clone(),
             state: self.state.clone(),
             listener: self.listener.try_clone().expect("listener clone"),
-            stop: self.stop.clone(),
+            shutdown: self.shutdown.clone(),
             backend_lock: self.backend_lock.clone(),
             capability: self.capability.clone(),
             authority: self.authority.clone(),
@@ -395,7 +463,7 @@ impl ServiceRunner {
             streaming_volume_enabled: self.streaming_volume_enabled,
             session_data: self.session_data.clone(),
             orbital_count: self.orbital_count,
-            control_transport: self.control_transport.clone(),
+            control_session: self.control_session.clone(),
             in_memory_session: self.in_memory_session,
             frontend_ready: self.frontend_ready.clone(),
             return_signaled: self.return_signaled.clone(),
@@ -512,8 +580,7 @@ impl ServiceRunner {
             }
             respond_json(&mut stream, &json!({"ok": true}), 200, false);
             self.volume_store.clear();
-            self.stop.store(true, Ordering::Release);
-            wake_listener(&self.listener);
+            self.shutdown.request();
             return;
         }
         if let Some(volume_id) = path.strip_prefix("/api/volume/") {
@@ -706,14 +773,10 @@ impl ServiceRunner {
         let result = signal_return(
             self.in_memory_session,
             &self.return_signaled,
-            &self.control_transport,
+            self.control_session.as_deref(),
             &self.session,
         );
         self.volume_store.clear();
-        if result.is_err() && self.in_memory_session {
-            terminate_control_session(&self.control_transport, &self.stop, &self.volume_store);
-            wake_listener(&self.listener);
-        }
         result
     }
 
@@ -764,18 +827,14 @@ impl ServiceRunner {
         let mut file_pending = None;
         if self.session_data.is_some() {
             let (sender, receiver) = std::sync::mpsc::channel();
-            let control_transport = self.control_transport.clone();
-            let stop = self.stop.clone();
-            let volume_store = self.volume_store.clone();
+            let control_session = self
+                .control_session
+                .as_ref()
+                .expect("in-memory session control")
+                .clone();
             std::thread::spawn(move || {
-                let result = request_control(
-                    &control_transport,
-                    &stop,
-                    &volume_store,
-                    request_id,
-                    &command,
-                    Duration::from_secs(300),
-                );
+                let result =
+                    control_session.request(request_id, &command, Duration::from_secs(300));
                 let _ = sender.send(result);
             });
             control_receiver = Some(receiver);
@@ -916,14 +975,10 @@ impl ServiceRunner {
             Ok(value) => value,
             Err(message) => return json!({"ok": false, "message": message}),
         };
-        request_control(
-            &self.control_transport,
-            &self.stop,
-            &self.volume_store,
-            backend::reserve_request_id(),
-            &command,
-            timeout,
-        )
+        self.control_session
+            .as_ref()
+            .expect("in-memory session control")
+            .request(backend::reserve_request_id(), &command, timeout)
     }
 
     fn request_control_esp(&self, query: &[(String, String)]) -> Value {
@@ -935,21 +990,21 @@ impl ServiceRunner {
             Ok(value) => value,
             Err(message) => return json!({"ok": false, "message": message}),
         };
-        request_control(
-            &self.control_transport,
-            &self.stop,
-            &self.volume_store,
-            backend::reserve_request_id(),
-            &command,
-            Duration::from_secs(900),
-        )
+        self.control_session
+            .as_ref()
+            .expect("in-memory session control")
+            .request(
+                backend::reserve_request_id(),
+                &command,
+                Duration::from_secs(900),
+            )
     }
 }
 
 fn signal_return(
     in_memory_session: bool,
     return_signaled: &Mutex<bool>,
-    control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
+    control_session: Option<&ControlSession>,
     session: &Path,
 ) -> Result<(), String> {
     let mut returned = return_signaled
@@ -959,22 +1014,9 @@ fn signal_return(
         return Ok(());
     }
     let result = if in_memory_session {
-        let body = json!({
-            "format": "multiwfn-matterviz-control",
-            "version": 1,
-            "kind": "shutdown",
-        });
-        let transport = control
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .as_ref()
-            .cloned();
-        match transport {
-            Some(transport) => transport
-                .send_json(MessageType::Shutdown, 0, &body)
-                .map_err(|error| format!("could not signal Multiwfn Return: {error}")),
-            None => Err("Multiwfn control transport is unavailable".to_owned()),
-        }
+        control_session
+            .ok_or_else(|| "Multiwfn control transport is unavailable".to_owned())?
+            .signal_return()
     } else {
         fs::write(session.join("gui_stop.flag"), "return\n")
             .map_err(|error| format!("could not signal Multiwfn Return: {error}"))
@@ -987,7 +1029,7 @@ fn signal_return(
 
 fn request_control(
     control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
-    stop: &AtomicBool,
+    shutdown: &ShutdownSignal,
     volume_store: &VolumeStore,
     request_id: u64,
     command: &str,
@@ -1037,7 +1079,7 @@ fn request_control(
     match result {
         Ok(value) => value,
         Err(message) => {
-            terminate_control_session(control, stop, volume_store);
+            terminate_control_session(control, shutdown, volume_store);
             json!({"ok": false, "message": message})
         }
     }
@@ -1045,7 +1087,7 @@ fn request_control(
 
 fn terminate_control_session(
     control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
-    stop: &AtomicBool,
+    shutdown: &ShutdownSignal,
     volume_store: &VolumeStore,
 ) {
     let mut guard = control
@@ -1053,7 +1095,7 @@ fn terminate_control_session(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     guard.take();
     volume_store.clear();
-    stop.store(true, Ordering::Release);
+    shutdown.request();
 }
 
 fn read_http_request(stream: &mut TcpStream) -> Result<(String, String), ()> {
@@ -1115,12 +1157,6 @@ fn bind(host: &str, port: u16) -> Result<TcpListener, String> {
     }
     socket.listen(128).map_err(|error| error.to_string())?;
     Ok(socket.into())
-}
-
-fn wake_listener(listener: &TcpListener) {
-    if let Ok(address) = listener.local_addr() {
-        let _ = TcpStream::connect_timeout(&address, Duration::from_millis(100));
-    }
 }
 
 fn new_socket(address: IpAddr) -> Result<Socket, String> {
@@ -1366,13 +1402,14 @@ fn respond(stream: &mut TcpStream, status: u16, content_type: &str, body: &[u8],
 #[cfg(test)]
 mod tests {
     use super::{
-        backend_response_status, content_type, decode_path, query_u64, request_control, safe_join,
-        AppConfig, HttpService,
+        backend_response_status, content_type, decode_path, query_u64, safe_join, AppConfig,
+        ControlSession, HttpService,
     };
     use crate::control_protocol::{
         decode_frame, decode_header, encode_frame, MessageType, HEADER_BYTES,
     };
     use crate::control_transport::ControlTransportConfig;
+    use crate::shutdown::ShutdownSignal;
     use crate::transport::TransportConfig;
     use crate::volume_protocol::{
         decode_ack, decode_volume, encode_volume, Crc32c, ACK_HEADER_BYTES, PRELUDE_BYTES,
@@ -1382,6 +1419,7 @@ mod tests {
     use std::io::{ErrorKind, Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::time::Duration;
 
     use url::Url;
@@ -1708,18 +1746,13 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn mismatched_control_response_invalidates_the_session() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex};
-
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, mut response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(Arc::new(
-            crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
-                read_pipe: into_raw_pipe(response_read),
-                write_pipe: into_raw_pipe(request_write),
-            })
-            .unwrap(),
-        ))));
+        let transport = crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: into_raw_pipe(response_read),
+            write_pipe: into_raw_pipe(request_write),
+        })
+        .unwrap();
         let producer = std::thread::spawn(move || {
             let request_bytes = read_control_frame(&mut request_read);
             assert_eq!(
@@ -1741,41 +1774,32 @@ mod tests {
                 response_write.write_all(chunk).unwrap();
             }
         });
-        let stop = AtomicBool::new(false);
-        let volumes = crate::volume_store::VolumeStore::new();
+        let shutdown = ShutdownSignal::detached();
+        let volumes = Arc::new(crate::volume_store::VolumeStore::new());
         volumes.insert(golden_frame()).unwrap();
-        let response = request_control(
-            &control,
-            &stop,
-            &volumes,
-            41,
-            "bond 1 2 mayer",
-            std::time::Duration::from_secs(1),
-        );
+        let control = ControlSession::new(transport, shutdown.clone(), volumes.clone());
+        let response = control.request(41, "bond 1 2 mayer", std::time::Duration::from_secs(1));
         producer.join().unwrap();
         assert_eq!(response["ok"], false);
         assert!(response["message"].as_str().unwrap().contains("Mismatched"));
-        assert!(stop.load(Ordering::Acquire));
-        assert!(control.lock().unwrap().is_none());
+        assert!(shutdown.is_requested());
+        assert!(!control.is_available());
         assert_eq!(volumes.bytes(), 0);
     }
 
     #[cfg(any(unix, windows))]
     #[test]
     fn return_is_not_blocked_by_a_pending_control_response() {
-        use std::sync::atomic::AtomicBool;
         use std::sync::{mpsc, Arc, Mutex};
         use std::time::{Duration, Instant};
 
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, mut response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(Arc::new(
-            crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
-                read_pipe: into_raw_pipe(response_read),
-                write_pipe: into_raw_pipe(request_write),
-            })
-            .unwrap(),
-        ))));
+        let transport = crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: into_raw_pipe(response_read),
+            write_pipe: into_raw_pipe(request_write),
+        })
+        .unwrap();
         let (request_seen, wait_for_request) = mpsc::channel();
         let producer = std::thread::spawn(move || {
             let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
@@ -1801,26 +1825,18 @@ mod tests {
             let shutdown = decode_frame(&read_control_frame(&mut request_read)).unwrap();
             assert_eq!(shutdown.header.message_type, MessageType::Shutdown);
         });
-        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = ShutdownSignal::detached();
         let volumes = Arc::new(crate::volume_store::VolumeStore::new());
+        let control = Arc::new(ControlSession::new(transport, shutdown, volumes));
         let request_control_handle = control.clone();
-        let request_stop = stop.clone();
-        let request_volumes = volumes.clone();
         let requester = std::thread::spawn(move || {
-            request_control(
-                &request_control_handle,
-                &request_stop,
-                &request_volumes,
-                91,
-                "bond 1 2 mayer",
-                Duration::from_secs(1),
-            )
+            request_control_handle.request(91, "bond 1 2 mayer", Duration::from_secs(1))
         });
         wait_for_request.recv().unwrap();
 
         let returned = Mutex::new(false);
         let started = Instant::now();
-        super::signal_return(true, &returned, &control, Path::new("unused")).unwrap();
+        super::signal_return(true, &returned, Some(&control), Path::new("unused")).unwrap();
         assert!(started.elapsed() < Duration::from_millis(100));
 
         assert_eq!(requester.join().unwrap()["ok"], true);
@@ -1830,9 +1846,6 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn control_result_requires_an_object_with_boolean_ok() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex};
-
         let cases = [
             ("missing result", None, false),
             ("null result", Some(serde_json::Value::Null), false),
@@ -1860,13 +1873,12 @@ mod tests {
         for (index, (name, result, valid)) in cases.into_iter().enumerate() {
             let (mut request_read, request_write) = pipe_pair();
             let (response_read, mut response_write) = pipe_pair();
-            let control = Arc::new(Mutex::new(Some(Arc::new(
+            let transport =
                 crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
                     read_pipe: into_raw_pipe(response_read),
                     write_pipe: into_raw_pipe(request_write),
                 })
-                .unwrap(),
-            ))));
+                .unwrap();
             let request_id = 70 + index as u64;
             let producer = std::thread::spawn(move || {
                 let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
@@ -1884,13 +1896,11 @@ mod tests {
                     encode_frame(MessageType::Response, request_id, Some(&response)).unwrap();
                 response_write.write_all(&frame).unwrap();
             });
-            let stop = AtomicBool::new(false);
-            let volumes = crate::volume_store::VolumeStore::new();
+            let shutdown = ShutdownSignal::detached();
+            let volumes = Arc::new(crate::volume_store::VolumeStore::new());
             volumes.insert(golden_frame()).unwrap();
-            let response = request_control(
-                &control,
-                &stop,
-                &volumes,
+            let control = ControlSession::new(transport, shutdown.clone(), volumes.clone());
+            let response = control.request(
                 request_id,
                 "bond 1 2 mayer",
                 std::time::Duration::from_secs(1),
@@ -1905,8 +1915,8 @@ mod tests {
                         .is_some(),
                     "{name}"
                 );
-                assert!(!stop.load(Ordering::Acquire), "{name}");
-                assert!(control.lock().unwrap().is_some(), "{name}");
+                assert!(!shutdown.is_requested(), "{name}");
+                assert!(control.is_available(), "{name}");
                 assert_ne!(volumes.bytes(), 0, "{name}");
             } else {
                 assert_eq!(response["ok"], false, "{name}");
@@ -1915,8 +1925,8 @@ mod tests {
                     "{name}"
                 );
                 assert_ne!(backend_response_status(&response), 200, "{name}");
-                assert!(stop.load(Ordering::Acquire), "{name}");
-                assert!(control.lock().unwrap().is_none(), "{name}");
+                assert!(shutdown.is_requested(), "{name}");
+                assert!(!control.is_available(), "{name}");
                 assert_eq!(volumes.bytes(), 0, "{name}");
             }
         }
@@ -2009,55 +2019,39 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn control_timeout_invalidates_the_session() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex};
-
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(Arc::new(
-            crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
-                read_pipe: into_raw_pipe(response_read),
-                write_pipe: into_raw_pipe(request_write),
-            })
-            .unwrap(),
-        ))));
+        let transport = crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: into_raw_pipe(response_read),
+            write_pipe: into_raw_pipe(request_write),
+        })
+        .unwrap();
         let producer = std::thread::spawn(move || {
             let _response_write = response_write;
             let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
             assert_eq!(request.header.request_id, 51);
             std::thread::sleep(std::time::Duration::from_millis(80));
         });
-        let stop = AtomicBool::new(false);
-        let volumes = crate::volume_store::VolumeStore::new();
-        let response = request_control(
-            &control,
-            &stop,
-            &volumes,
-            51,
-            "bond 1 2 mayer",
-            std::time::Duration::from_millis(20),
-        );
+        let shutdown = ShutdownSignal::detached();
+        let volumes = Arc::new(crate::volume_store::VolumeStore::new());
+        let control = ControlSession::new(transport, shutdown.clone(), volumes);
+        let response = control.request(51, "bond 1 2 mayer", std::time::Duration::from_millis(20));
         producer.join().unwrap();
         assert!(response["message"].as_str().unwrap().contains("timed out"));
-        assert!(stop.load(Ordering::Acquire));
-        assert!(control.lock().unwrap().is_none());
+        assert!(shutdown.is_requested());
+        assert!(!control.is_available());
     }
 
     #[cfg(any(unix, windows))]
     #[test]
     fn corrupt_control_response_invalidates_the_session() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::{Arc, Mutex};
-
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, mut response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(Arc::new(
-            crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
-                read_pipe: into_raw_pipe(response_read),
-                write_pipe: into_raw_pipe(request_write),
-            })
-            .unwrap(),
-        ))));
+        let transport = crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+            read_pipe: into_raw_pipe(response_read),
+            write_pipe: into_raw_pipe(request_write),
+        })
+        .unwrap();
         let producer = std::thread::spawn(move || {
             let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
             let response = serde_json::json!({
@@ -2076,20 +2070,14 @@ mod tests {
             *frame.last_mut().unwrap() ^= 1;
             response_write.write_all(&frame).unwrap();
         });
-        let stop = AtomicBool::new(false);
-        let volumes = crate::volume_store::VolumeStore::new();
-        let response = request_control(
-            &control,
-            &stop,
-            &volumes,
-            61,
-            "bond 1 2 mayer",
-            std::time::Duration::from_secs(1),
-        );
+        let shutdown = ShutdownSignal::detached();
+        let volumes = Arc::new(crate::volume_store::VolumeStore::new());
+        let control = ControlSession::new(transport, shutdown.clone(), volumes);
+        let response = control.request(61, "bond 1 2 mayer", std::time::Duration::from_secs(1));
         producer.join().unwrap();
         assert!(response["message"].as_str().unwrap().contains("CRC32C"));
-        assert!(stop.load(Ordering::Acquire));
-        assert!(control.lock().unwrap().is_none());
+        assert!(shutdown.is_requested());
+        assert!(!control.is_available());
     }
 
     #[cfg(any(unix, windows))]

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -22,6 +22,13 @@ use crate::volume_store::VolumeStore;
 use serde_json::{json, Value};
 use socket2::{Domain, Protocol, Socket, Type};
 
+const SESSION_BOOTSTRAP_STAGE_TIMEOUT: Duration = Duration::from_secs(30);
+const SESSION_BOOTSTRAP_STAGES: u32 = 3; // Two optional initial volumes, then session_init.
+
+fn session_bootstrap_wait_timeout(stage_timeout: Duration) -> Duration {
+    stage_timeout.saturating_mul(SESSION_BOOTSTRAP_STAGES)
+}
+
 #[derive(Clone, Debug)]
 pub struct AppConfig {
     pub frontend: PathBuf,
@@ -61,6 +68,18 @@ impl HttpService {
     pub fn start_with_control(
         config: AppConfig,
         control_config: Option<ControlTransportConfig>,
+    ) -> Result<Self, String> {
+        Self::start_with_control_stage_timeout(
+            config,
+            control_config,
+            SESSION_BOOTSTRAP_STAGE_TIMEOUT,
+        )
+    }
+
+    fn start_with_control_stage_timeout(
+        config: AppConfig,
+        control_config: Option<ControlTransportConfig>,
+        bootstrap_stage_timeout: Duration,
     ) -> Result<Self, String> {
         let in_memory_session = control_config.is_some();
         let frontend = config
@@ -150,7 +169,10 @@ impl HttpService {
                     .send_hello()
                     .map_err(|error| format!("could not start control transport: {error}"))?;
                 let frame = transport
-                    .read_frame_timeout(Duration::from_secs(30))
+                    .read_frame_startup(
+                        session_bootstrap_wait_timeout(bootstrap_stage_timeout),
+                        bootstrap_stage_timeout,
+                    )
                     .map_err(|error| format!("could not receive session bootstrap: {error}"))?;
                 let data = SessionData::from_frame(&frame)
                     .map_err(|error| format!("invalid session bootstrap: {error}"))?;
@@ -1297,7 +1319,10 @@ mod tests {
     };
     use crate::control_transport::ControlTransportConfig;
     use crate::transport::TransportConfig;
-    use crate::volume_protocol::{Crc32c, ACK_HEADER_BYTES, PRELUDE_BYTES, VOLUME_HEADER_BYTES};
+    use crate::volume_protocol::{
+        decode_ack, decode_volume, encode_volume, Crc32c, ACK_HEADER_BYTES, PRELUDE_BYTES,
+        VOLUME_HEADER_BYTES,
+    };
     use std::fs;
     use std::io::{ErrorKind, Read, Write};
     use std::net::{TcpListener, TcpStream};
@@ -1402,6 +1427,89 @@ mod tests {
         join_service(service);
         assert!(!session.exists());
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn delayed_initial_volumes_complete_before_session_bootstrap() {
+        for volume_count in 1_u64..=2 {
+            let root = fixture(&format!("delayed-bootstrap-{volume_count}"));
+            let frontend = root.join("frontend");
+            let session = root.join("session-must-not-exist");
+            fs::create_dir_all(&frontend).unwrap();
+            fs::write(frontend.join("index.html"), "MatterViz").unwrap();
+
+            let (volume_read, mut volume_write) = pipe_pair();
+            let (mut ack_read, ack_write) = pipe_pair();
+            let (mut hello_read, hello_write) = pipe_pair();
+            let (bootstrap_read, mut bootstrap_write) = pipe_pair();
+            let producer = std::thread::spawn(move || {
+                let hello = decode_frame(&read_control_frame(&mut hello_read)).unwrap();
+                assert_eq!(hello.header.message_type, MessageType::Hello);
+                let mut ready = [0_u8; PRELUDE_BYTES];
+                ack_read.read_exact(&mut ready).unwrap();
+
+                for offset in 0..volume_count {
+                    let mut volume = decode_volume(&golden_frame()).unwrap();
+                    volume.request_id += offset;
+                    volume.volume_id += offset;
+                    let frame = encode_volume(&volume).unwrap();
+                    let chunk_len = frame.len().div_ceil(4);
+                    for chunk in frame.chunks(chunk_len) {
+                        std::thread::sleep(std::time::Duration::from_millis(45));
+                        volume_write.write_all(chunk).unwrap();
+                    }
+                    let mut ack = [0_u8; ACK_HEADER_BYTES];
+                    ack_read.read_exact(&mut ack).unwrap();
+                    assert_eq!(decode_ack(&ack).unwrap().2, 0);
+                }
+
+                let body = serde_json::json!({
+                    "format": "multiwfn-matterviz-control",
+                    "version": 1,
+                    "kind": "session_init",
+                    "manifest": {
+                        "format": "multiwfn-matterviz-workbench",
+                        "version": 2,
+                        "structure": null,
+                        "cubes": []
+                    },
+                    "structure": null
+                });
+                bootstrap_write
+                    .write_all(&encode_frame(MessageType::SessionInit, 0, Some(&body)).unwrap())
+                    .unwrap();
+                let shutdown = decode_frame(&read_control_frame(&mut hello_read)).unwrap();
+                assert_eq!(shutdown.header.message_type, MessageType::Shutdown);
+            });
+
+            let service = HttpService::start_with_control_stage_timeout(
+                AppConfig {
+                    frontend,
+                    session: session.clone(),
+                    manifest: None,
+                    state: None,
+                    host: "127.0.0.1".to_owned(),
+                    port: 0,
+                    transport: Some(TransportConfig {
+                        volume_read_pipe: into_raw_pipe(volume_read),
+                        volume_ack_pipe: into_raw_pipe(ack_write),
+                    }),
+                },
+                Some(ControlTransportConfig {
+                    read_pipe: into_raw_pipe(bootstrap_read),
+                    write_pipe: into_raw_pipe(hello_write),
+                }),
+                std::time::Duration::from_millis(300),
+            )
+            .unwrap();
+            service.signal_return().unwrap();
+            service.shutdown();
+            service.join();
+            producer.join().unwrap();
+            assert!(!session.exists());
+            let _ = fs::remove_dir_all(root);
+        }
     }
 
     #[cfg(any(unix, windows))]

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -52,11 +52,11 @@ pub struct HttpService {
     stream_broker: Arc<VolumeStreamBroker>,
     streaming_volume_enabled: bool,
     transport: Mutex<Option<VolumeTransport>>,
-    control_transport: Arc<Mutex<Option<ControlTransport>>>,
+    control_transport: Arc<Mutex<Option<Arc<ControlTransport>>>>,
     session_data: Option<SessionData>,
     in_memory_session: bool,
     frontend_ready: Arc<AtomicBool>,
-    return_signaled: Arc<AtomicBool>,
+    return_signaled: Arc<Mutex<bool>>,
     worker: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
@@ -172,7 +172,7 @@ impl HttpService {
             .transpose()?;
         let (control_transport, session_data) = control_config
             .map(|config| {
-                let mut transport = ControlTransport::adopt(config)
+                let transport = ControlTransport::adopt(config)
                     .map_err(|error| format!("could not adopt control transport: {error}"))?;
                 transport
                     .send_hello()
@@ -189,7 +189,7 @@ impl HttpService {
             })
             .transpose()?
             .map_or((None, None), |(transport, data)| {
-                (Some(transport), Some(data))
+                (Some(Arc::new(transport)), Some(data))
             });
         let has_state = state.is_some()
             || session_data
@@ -223,7 +223,7 @@ impl HttpService {
             session_data,
             in_memory_session,
             frontend_ready,
-            return_signaled: Arc::new(AtomicBool::new(false)),
+            return_signaled: Arc::new(Mutex::new(false)),
             worker: Mutex::new(None),
         };
         let runner = service.clone_for_thread(frontend, manifest, state);
@@ -287,7 +287,10 @@ impl HttpService {
     }
     pub fn termination_exit_code(&self) -> i32 {
         if self.in_memory_session
-            && (!self.return_signaled.load(Ordering::Acquire)
+            && (!*self
+                .return_signaled
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
                 || self
                     .control_transport
                     .lock()
@@ -350,10 +353,10 @@ struct ServiceRunner {
     streaming_volume_enabled: bool,
     session_data: Option<SessionData>,
     orbital_count: Option<i64>,
-    control_transport: Arc<Mutex<Option<ControlTransport>>>,
+    control_transport: Arc<Mutex<Option<Arc<ControlTransport>>>>,
     in_memory_session: bool,
     frontend_ready: Arc<AtomicBool>,
-    return_signaled: Arc<AtomicBool>,
+    return_signaled: Arc<Mutex<bool>>,
 }
 impl ServiceRunner {
     fn run(self) {
@@ -945,11 +948,14 @@ impl ServiceRunner {
 
 fn signal_return(
     in_memory_session: bool,
-    return_signaled: &AtomicBool,
-    control: &Arc<Mutex<Option<ControlTransport>>>,
+    return_signaled: &Mutex<bool>,
+    control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
     session: &Path,
 ) -> Result<(), String> {
-    if return_signaled.swap(true, Ordering::AcqRel) {
+    let mut returned = return_signaled
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if *returned {
         return Ok(());
     }
     let result = if in_memory_session {
@@ -958,10 +964,12 @@ fn signal_return(
             "version": 1,
             "kind": "shutdown",
         });
-        let guard = control
+        let transport = control
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        match guard.as_ref() {
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .cloned();
+        match transport {
             Some(transport) => transport
                 .send_json(MessageType::Shutdown, 0, &body)
                 .map_err(|error| format!("could not signal Multiwfn Return: {error}")),
@@ -971,24 +979,26 @@ fn signal_return(
         fs::write(session.join("gui_stop.flag"), "return\n")
             .map_err(|error| format!("could not signal Multiwfn Return: {error}"))
     };
-    if result.is_err() {
-        return_signaled.store(false, Ordering::Release);
+    if result.is_ok() {
+        *returned = true;
     }
     result
 }
 
 fn request_control(
-    control: &Arc<Mutex<Option<ControlTransport>>>,
+    control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
     stop: &AtomicBool,
     volume_store: &VolumeStore,
     request_id: u64,
     command: &str,
     timeout: Duration,
 ) -> Value {
-    let mut guard = control
+    let transport = control
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let Some(transport) = guard.as_mut() else {
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .as_ref()
+        .cloned();
+    let Some(transport) = transport else {
         return json!({"ok": false, "message": backend::BACKEND_UNAVAILABLE});
     };
     let result = transport
@@ -1027,7 +1037,6 @@ fn request_control(
     match result {
         Ok(value) => value,
         Err(message) => {
-            drop(guard);
             terminate_control_session(control, stop, volume_store);
             json!({"ok": false, "message": message})
         }
@@ -1035,16 +1044,14 @@ fn request_control(
 }
 
 fn terminate_control_session(
-    control: &Arc<Mutex<Option<ControlTransport>>>,
+    control: &Arc<Mutex<Option<Arc<ControlTransport>>>>,
     stop: &AtomicBool,
     volume_store: &VolumeStore,
 ) {
     let mut guard = control
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Some(mut transport) = guard.take() {
-        transport.close();
-    }
+    guard.take();
     volume_store.clear();
     stop.store(true, Ordering::Release);
 }
@@ -1701,13 +1708,13 @@ mod tests {
 
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, mut response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(
+        let control = Arc::new(Mutex::new(Some(Arc::new(
             crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
                 read_pipe: into_raw_pipe(response_read),
                 write_pipe: into_raw_pipe(request_write),
             })
             .unwrap(),
-        )));
+        ))));
         let producer = std::thread::spawn(move || {
             let request_bytes = read_control_frame(&mut request_read);
             assert_eq!(
@@ -1750,6 +1757,73 @@ mod tests {
 
     #[cfg(any(unix, windows))]
     #[test]
+    fn return_is_not_blocked_by_a_pending_control_response() {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{mpsc, Arc, Mutex};
+        use std::time::{Duration, Instant};
+
+        let (mut request_read, request_write) = pipe_pair();
+        let (response_read, mut response_write) = pipe_pair();
+        let control = Arc::new(Mutex::new(Some(Arc::new(
+            crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
+                read_pipe: into_raw_pipe(response_read),
+                write_pipe: into_raw_pipe(request_write),
+            })
+            .unwrap(),
+        ))));
+        let (request_seen, wait_for_request) = mpsc::channel();
+        let producer = std::thread::spawn(move || {
+            let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
+            request_seen.send(()).unwrap();
+            std::thread::sleep(Duration::from_millis(250));
+            let response = serde_json::json!({
+                "format": "multiwfn-matterviz-control",
+                "version": 1,
+                "kind": "response",
+                "request_id": request.header.request_id,
+                "result": {"ok": true}
+            });
+            response_write
+                .write_all(
+                    &encode_frame(
+                        MessageType::Response,
+                        request.header.request_id,
+                        Some(&response),
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+            let shutdown = decode_frame(&read_control_frame(&mut request_read)).unwrap();
+            assert_eq!(shutdown.header.message_type, MessageType::Shutdown);
+        });
+        let stop = Arc::new(AtomicBool::new(false));
+        let volumes = Arc::new(crate::volume_store::VolumeStore::new());
+        let request_control_handle = control.clone();
+        let request_stop = stop.clone();
+        let request_volumes = volumes.clone();
+        let requester = std::thread::spawn(move || {
+            request_control(
+                &request_control_handle,
+                &request_stop,
+                &request_volumes,
+                91,
+                "bond 1 2 mayer",
+                Duration::from_secs(1),
+            )
+        });
+        wait_for_request.recv().unwrap();
+
+        let returned = Mutex::new(false);
+        let started = Instant::now();
+        super::signal_return(true, &returned, &control, Path::new("unused")).unwrap();
+        assert!(started.elapsed() < Duration::from_millis(100));
+
+        assert_eq!(requester.join().unwrap()["ok"], true);
+        producer.join().unwrap();
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
     fn control_result_requires_an_object_with_boolean_ok() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::{Arc, Mutex};
@@ -1781,13 +1855,13 @@ mod tests {
         for (index, (name, result, valid)) in cases.into_iter().enumerate() {
             let (mut request_read, request_write) = pipe_pair();
             let (response_read, mut response_write) = pipe_pair();
-            let control = Arc::new(Mutex::new(Some(
+            let control = Arc::new(Mutex::new(Some(Arc::new(
                 crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
                     read_pipe: into_raw_pipe(response_read),
                     write_pipe: into_raw_pipe(request_write),
                 })
                 .unwrap(),
-            )));
+            ))));
             let request_id = 70 + index as u64;
             let producer = std::thread::spawn(move || {
                 let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
@@ -1935,13 +2009,13 @@ mod tests {
 
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(
+        let control = Arc::new(Mutex::new(Some(Arc::new(
             crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
                 read_pipe: into_raw_pipe(response_read),
                 write_pipe: into_raw_pipe(request_write),
             })
             .unwrap(),
-        )));
+        ))));
         let producer = std::thread::spawn(move || {
             let _response_write = response_write;
             let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
@@ -1972,13 +2046,13 @@ mod tests {
 
         let (mut request_read, request_write) = pipe_pair();
         let (response_read, mut response_write) = pipe_pair();
-        let control = Arc::new(Mutex::new(Some(
+        let control = Arc::new(Mutex::new(Some(Arc::new(
             crate::control_transport::ControlTransport::adopt(ControlTransportConfig {
                 read_pipe: into_raw_pipe(response_read),
                 write_pipe: into_raw_pipe(request_write),
             })
             .unwrap(),
-        )));
+        ))));
         let producer = std::thread::spawn(move || {
             let request = decode_frame(&read_control_frame(&mut request_read)).unwrap();
             let response = serde_json::json!({

--- a/frontend/matterviz-desktop/src/shutdown.rs
+++ b/frontend/matterviz-desktop/src/shutdown.rs
@@ -1,0 +1,75 @@
+use std::net::{SocketAddr, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct ShutdownSignal {
+    requested: Arc<AtomicBool>,
+    wake_address: Option<SocketAddr>,
+}
+
+impl ShutdownSignal {
+    pub fn new(wake_address: SocketAddr) -> Self {
+        Self {
+            requested: Arc::new(AtomicBool::new(false)),
+            wake_address: Some(wake_address),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn detached() -> Self {
+        Self {
+            requested: Arc::new(AtomicBool::new(false)),
+            wake_address: None,
+        }
+    }
+
+    pub fn is_requested(&self) -> bool {
+        self.requested.load(Ordering::Acquire)
+    }
+
+    pub fn request(&self) {
+        self.requested.store(true, Ordering::Release);
+        if let Some(address) = self.wake_address {
+            let _ = TcpStream::connect_timeout(&address, Duration::from_millis(100));
+        }
+    }
+
+    pub fn flag(&self) -> &AtomicBool {
+        &self.requested
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShutdownSignal;
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn detached_shutdown_is_idempotent() {
+        let shutdown = ShutdownSignal::detached();
+        assert!(!shutdown.is_requested());
+        shutdown.request();
+        shutdown.request();
+        assert!(shutdown.is_requested());
+    }
+
+    #[test]
+    fn shutdown_wakes_the_listener() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let shutdown = ShutdownSignal::new(listener.local_addr().unwrap());
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let accepted = listener.accept().is_ok();
+            let _ = sender.send(accepted);
+        });
+
+        shutdown.request();
+
+        assert!(receiver.recv_timeout(Duration::from_secs(1)).unwrap());
+        assert!(shutdown.is_requested());
+    }
+}

--- a/frontend/matterviz-desktop/src/transport.rs
+++ b/frontend/matterviz-desktop/src/transport.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::{SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use crate::shutdown::ShutdownSignal;
 use crate::stream_broker::{StreamEvent, VolumeStreamBroker};
 use crate::volume_protocol::{
     declared_volume_frame_len, decode_stream_volume_header, encode_ack, encode_ready,
@@ -25,16 +26,21 @@ impl VolumeTransport {
     pub fn start(
         config: TransportConfig,
         store: Arc<VolumeStore>,
-        stop: Arc<AtomicBool>,
+        shutdown: ShutdownSignal,
     ) -> Result<Self, String> {
-        Self::start_with_broker(config, store, Arc::new(VolumeStreamBroker::default()), stop)
+        Self::start_with_broker(
+            config,
+            store,
+            Arc::new(VolumeStreamBroker::default()),
+            shutdown,
+        )
     }
 
     pub fn start_with_broker(
         config: TransportConfig,
         store: Arc<VolumeStore>,
         broker: Arc<VolumeStreamBroker>,
-        stop: Arc<AtomicBool>,
+        shutdown: ShutdownSignal,
     ) -> Result<Self, String> {
         let reader = platform::PipeReader::adopt(config.volume_read_pipe)
             .map_err(|error| format!("could not adopt volume read pipe: {error}"))?;
@@ -42,7 +48,7 @@ impl VolumeTransport {
             .map_err(|error| format!("could not adopt volume ACK pipe: {error}"))?;
         let worker = thread::Builder::new()
             .name("matterviz-volume-reader".to_owned())
-            .spawn(move || run(reader, writer, store, broker, stop))
+            .spawn(move || run(reader, writer, store, broker, shutdown))
             .map_err(|error| format!("could not start volume reader: {error}"))?;
         Ok(Self {
             worker: Mutex::new(Some(worker)),
@@ -61,16 +67,16 @@ fn run(
     mut writer: platform::PipeWriter,
     store: Arc<VolumeStore>,
     broker: Arc<VolumeStreamBroker>,
-    stop: Arc<AtomicBool>,
+    shutdown: ShutdownSignal,
 ) {
     if writer.write_all(&encode_ready()).is_err() {
         store.clear();
-        stop.store(true, Ordering::Release);
+        shutdown.request();
         return;
     }
-    while !stop.load(Ordering::Acquire) {
+    while !shutdown.is_requested() {
         let mut prelude = [0_u8; PRELUDE_BYTES];
-        if read_exact(&mut reader, &mut prelude, &stop).is_err() {
+        if read_exact(&mut reader, &mut prelude, shutdown.flag()).is_err() {
             break;
         }
         let major = match protocol_major(&prelude) {
@@ -78,9 +84,9 @@ fn run(
             Err(_) => break,
         };
         let result = if major == STREAM_MAJOR {
-            receive_stream_volume(&mut reader, &mut writer, &broker, &stop, prelude)
+            receive_stream_volume(&mut reader, &mut writer, &broker, shutdown.flag(), prelude)
         } else {
-            receive_buffered_volume(&mut reader, &mut writer, &store, &stop, prelude)
+            receive_buffered_volume(&mut reader, &mut writer, &store, shutdown.flag(), prelude)
         };
         if result.is_err() {
             break;
@@ -88,7 +94,7 @@ fn run(
     }
     store.clear();
     broker.fail_all("MatterViz volume transport closed");
-    stop.store(true, Ordering::Release);
+    shutdown.request();
 }
 
 fn receive_buffered_volume(
@@ -499,9 +505,9 @@ mod tests {
         let store = Arc::new(VolumeStore::new());
         let broker = Arc::new(VolumeStreamBroker::default());
         let registration = broker.register(42).unwrap();
-        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = ShutdownSignal::detached();
         let transport =
-            VolumeTransport::start_with_broker(config, store.clone(), broker.clone(), stop)
+            VolumeTransport::start_with_broker(config, store.clone(), broker.clone(), shutdown)
                 .unwrap();
         let mut ready = [0_u8; PRELUDE_BYTES];
         ack_read.read_exact(&mut ready).unwrap();
@@ -554,9 +560,9 @@ mod tests {
         };
         let store = Arc::new(VolumeStore::new());
         let broker = Arc::new(VolumeStreamBroker::default());
-        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = ShutdownSignal::detached();
         let transport =
-            VolumeTransport::start_with_broker(config, store, broker.clone(), stop).unwrap();
+            VolumeTransport::start_with_broker(config, store, broker.clone(), shutdown).unwrap();
         let mut ready = [0_u8; PRELUDE_BYTES];
         ack_read.read_exact(&mut ready).unwrap();
 
@@ -598,8 +604,8 @@ mod tests {
             volume_ack_pipe: into_raw_pipe(ack_write),
         };
         let store = Arc::new(VolumeStore::new());
-        let stop = Arc::new(AtomicBool::new(false));
-        let transport = VolumeTransport::start(config, store.clone(), stop.clone()).unwrap();
+        let shutdown = ShutdownSignal::detached();
+        let transport = VolumeTransport::start(config, store.clone(), shutdown).unwrap();
         let mut ready = [0_u8; PRELUDE_BYTES];
         ack_read.read_exact(&mut ready).unwrap();
         crate::volume_protocol::decode_ready(&ready).unwrap();
@@ -650,8 +656,9 @@ mod tests {
                 volume_ack_pipe: into_raw_pipe(ack_write),
             };
             let store = Arc::new(VolumeStore::new());
-            let stop = Arc::new(AtomicBool::new(false));
-            let transport = VolumeTransport::start(config, store.clone(), stop.clone()).unwrap();
+            let shutdown = ShutdownSignal::detached();
+            let transport =
+                VolumeTransport::start(config, store.clone(), shutdown.clone()).unwrap();
             let mut ready = [0_u8; PRELUDE_BYTES];
             ack_read.read_exact(&mut ready).unwrap();
             crate::volume_protocol::decode_ready(&ready).unwrap();
@@ -660,14 +667,14 @@ mod tests {
                 volume_write.write_all(&fixture()[..length]).unwrap();
                 drop(volume_write);
             } else {
-                stop.store(true, Ordering::Release);
+                shutdown.request();
             }
 
             let started = Instant::now();
             transport.join();
             assert!(started.elapsed() < Duration::from_secs(2));
             assert!(store.is_empty());
-            assert!(stop.load(Ordering::Acquire));
+            assert!(shutdown.is_requested());
         }
     }
 

--- a/frontend/matterviz-desktop/src/transport.rs
+++ b/frontend/matterviz-desktop/src/transport.rs
@@ -207,9 +207,10 @@ fn frame_identity(frame: &[u8]) -> Option<(u64, u64)> {
 
 #[cfg(unix)]
 mod platform {
+    use crate::inherited_pipe;
     use std::fs::File;
     use std::io::{self, Read, Write};
-    use std::os::fd::{FromRawFd, RawFd};
+    use std::os::fd::AsRawFd;
     use std::thread;
     use std::time::Duration;
 
@@ -224,14 +225,15 @@ mod platform {
 
     impl PipeReader {
         pub fn adopt(raw: u64) -> io::Result<Self> {
-            let raw = RawFd::try_from(raw)
-                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "pipe fd is too large"))?;
-            let flags = unsafe { libc::fcntl(raw, libc::F_GETFL) };
-            if flags < 0 || unsafe { libc::fcntl(raw, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+            let file = inherited_pipe::adopt(raw)?;
+            let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+            if flags < 0
+                || unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) }
+                    < 0
             {
                 return Err(io::Error::last_os_error());
             }
-            Ok(Self(unsafe { File::from_raw_fd(raw) }))
+            Ok(Self(file))
         }
 
         pub fn read_available(&mut self, buffer: &mut [u8]) -> io::Result<ReadState> {
@@ -250,9 +252,7 @@ mod platform {
 
     impl PipeWriter {
         pub fn adopt(raw: u64) -> io::Result<Self> {
-            let raw = RawFd::try_from(raw)
-                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "pipe fd is too large"))?;
-            Ok(Self(unsafe { File::from_raw_fd(raw) }))
+            inherited_pipe::adopt(raw).map(Self)
         }
 
         pub fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
@@ -263,8 +263,10 @@ mod platform {
 
 #[cfg(windows)]
 mod platform {
+    use crate::inherited_pipe;
+    use std::fs::File;
     use std::io;
-    use std::os::windows::io::{FromRawHandle, OwnedHandle, RawHandle};
+    use std::os::windows::io::AsRawHandle;
     use std::thread;
     use std::time::Duration;
 
@@ -278,24 +280,12 @@ mod platform {
         Eof,
     }
 
-    pub struct PipeReader(OwnedHandle);
-    pub struct PipeWriter(OwnedHandle);
-
-    fn adopt(raw: u64) -> io::Result<OwnedHandle> {
-        let raw = usize::try_from(raw)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "pipe handle is too large"))?;
-        if raw == 0 || raw == usize::MAX {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid pipe handle",
-            ));
-        }
-        Ok(unsafe { OwnedHandle::from_raw_handle(raw as RawHandle) })
-    }
+    pub struct PipeReader(File);
+    pub struct PipeWriter(File);
 
     impl PipeReader {
         pub fn adopt(raw: u64) -> io::Result<Self> {
-            adopt(raw).map(Self)
+            inherited_pipe::adopt(raw).map(Self)
         }
 
         pub fn read_available(&mut self, buffer: &mut [u8]) -> io::Result<ReadState> {
@@ -352,7 +342,7 @@ mod platform {
 
     impl PipeWriter {
         pub fn adopt(raw: u64) -> io::Result<Self> {
-            adopt(raw).map(Self)
+            inherited_pipe::adopt(raw).map(Self)
         }
 
         pub fn write_all(&mut self, mut bytes: &[u8]) -> io::Result<()> {
@@ -383,8 +373,6 @@ mod platform {
             Ok(())
         }
     }
-
-    use std::os::windows::io::AsRawHandle;
 }
 
 #[cfg(test)]
@@ -404,6 +392,42 @@ mod tests {
         let read = unsafe { std::fs::File::from_raw_fd(ends[0]) };
         let write = unsafe { std::fs::File::from_raw_fd(ends[1]) };
         (read, write)
+    }
+
+    #[cfg(unix)]
+    fn clear_close_on_exec(fd: std::os::fd::RawFd) {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_eq!(
+            unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) },
+            0
+        );
+    }
+
+    #[cfg(unix)]
+    fn assert_close_on_exec(fd: std::os::fd::RawFd) {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn adopted_volume_descriptors_are_close_on_exec() {
+        use std::os::fd::IntoRawFd;
+
+        let (read_volume, _write_volume) = pipe_pair();
+        let (_read_ack, write_ack) = pipe_pair();
+        let read_fd = read_volume.into_raw_fd();
+        let write_fd = write_ack.into_raw_fd();
+        clear_close_on_exec(read_fd);
+        clear_close_on_exec(write_fd);
+
+        let _reader = platform::PipeReader::adopt(read_fd as u64).unwrap();
+        let _writer = platform::PipeWriter::adopt(write_fd as u64).unwrap();
+
+        assert_close_on_exec(read_fd);
+        assert_close_on_exec(write_fd);
     }
 
     #[cfg(windows)]

--- a/frontend/matterviz-desktop/src/transport.rs
+++ b/frontend/matterviz-desktop/src/transport.rs
@@ -19,6 +19,7 @@ pub struct TransportConfig {
 
 pub struct VolumeTransport {
     worker: Mutex<Option<thread::JoinHandle<()>>>,
+    shutdown: ShutdownSignal,
 }
 
 impl VolumeTransport {
@@ -46,12 +47,14 @@ impl VolumeTransport {
             .map_err(|error| format!("could not adopt volume read pipe: {error}"))?;
         let writer = platform::PipeWriter::adopt(config.volume_ack_pipe)
             .map_err(|error| format!("could not adopt volume ACK pipe: {error}"))?;
+        let worker_shutdown = shutdown.clone();
         let worker = thread::Builder::new()
             .name("matterviz-volume-reader".to_owned())
-            .spawn(move || run(reader, writer, store, broker, shutdown))
+            .spawn(move || run(reader, writer, store, broker, worker_shutdown))
             .map_err(|error| format!("could not start volume reader: {error}"))?;
         Ok(Self {
             worker: Mutex::new(Some(worker)),
+            shutdown,
         })
     }
 
@@ -59,6 +62,13 @@ impl VolumeTransport {
         if let Some(worker) = self.worker.lock().expect("transport worker lock").take() {
             let _ = worker.join();
         }
+    }
+}
+
+impl Drop for VolumeTransport {
+    fn drop(&mut self) {
+        self.shutdown.request();
+        self.join();
     }
 }
 
@@ -676,6 +686,28 @@ mod tests {
             assert!(store.is_empty());
             assert!(shutdown.is_requested());
         }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn dropping_transport_requests_shutdown_and_joins_worker() {
+        let (volume_read, _volume_write) = pipe_pair();
+        let (mut ack_read, ack_write) = pipe_pair();
+        let config = TransportConfig {
+            volume_read_pipe: into_raw_pipe(volume_read),
+            volume_ack_pipe: into_raw_pipe(ack_write),
+        };
+        let shutdown = ShutdownSignal::detached();
+        let transport =
+            VolumeTransport::start(config, Arc::new(VolumeStore::new()), shutdown.clone()).unwrap();
+        let mut ready = [0_u8; PRELUDE_BYTES];
+        ack_read.read_exact(&mut ready).unwrap();
+
+        let started = Instant::now();
+        drop(transport);
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(shutdown.is_requested());
     }
 
     #[cfg(unix)]

--- a/frontend/matterviz-viewer/src/App.svelte
+++ b/frontend/matterviz-viewer/src/App.svelte
@@ -54,6 +54,7 @@
     type MatterVizWorkbenchState,
     type WorkbenchCameraState,
   } from './state'
+  import { signal_frontend_ready } from './startup'
   import { AXIS_PRESETS, type SliceAxis, type SliceColormap } from './slice'
   import {
     adapt_matterviz_volume,
@@ -679,6 +680,7 @@
       }
       set_status(entries.length ? `${entries.length} volume layer(s) loaded` : 'Structure loaded')
       if (startupState) apply_workbench_state(startupState)
+      await signal_frontend_ready()
     } catch (error) {
       report_error(error)
       status = 'Session loading failed'

--- a/frontend/matterviz-viewer/src/startup.ts
+++ b/frontend/matterviz-viewer/src/startup.ts
@@ -1,0 +1,20 @@
+export type ReadyFetch = (
+  input: URL,
+  init: RequestInit,
+) => Promise<Pick<Response, 'ok' | 'status' | 'json'>>
+
+export const signal_frontend_ready = async (
+  page: URL = new URL(window.location.href),
+  request: ReadyFetch = (input, init) => fetch(input, init),
+): Promise<boolean> => {
+  const capability = page.searchParams.get('cap')
+  if (!capability) return false
+
+  const endpoint = new URL('/api/ready', page)
+  endpoint.searchParams.set('cap', capability)
+  const response = await request(endpoint, { method: 'POST', cache: 'no-store' })
+  if (!response.ok) throw new Error(`MatterViz readiness request returned HTTP ${response.status}`)
+  const payload = await response.json() as { ok?: unknown }
+  if (payload.ok !== true) throw new Error('MatterViz readiness request was rejected')
+  return true
+}

--- a/frontend/matterviz-viewer/tests/startup.test.ts
+++ b/frontend/matterviz-viewer/tests/startup.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { signal_frontend_ready, type ReadyFetch } from '../src/startup.ts'
+
+test('does not report ready outside a capability-bound managed session', async () => {
+  let requests = 0
+  const request: ReadyFetch = async () => {
+    requests += 1
+    throw new Error('unexpected readiness request')
+  }
+
+  assert.equal(
+    await signal_frontend_ready(new URL('http://127.0.0.1:8765/index.html'), request),
+    false,
+  )
+  assert.equal(requests, 0)
+})
+
+test('posts readiness with only the current session capability', async () => {
+  let requestedUrl: URL | undefined
+  let requestedInit: RequestInit | undefined
+  const request: ReadyFetch = async (url, init) => {
+    requestedUrl = url
+    requestedInit = init
+    return { ok: true, status: 200, json: async () => ({ ok: true }) }
+  }
+
+  const ready = await signal_frontend_ready(
+    new URL('http://127.0.0.1:8765/index.html?manifest=/session/manifest.json&cap=session-secret'),
+    request,
+  )
+
+  assert.equal(ready, true)
+  assert.equal(requestedUrl?.href, 'http://127.0.0.1:8765/api/ready?cap=session-secret')
+  assert.deepEqual(requestedInit, { method: 'POST', cache: 'no-store' })
+})
+
+test('rejects a failed readiness acknowledgement', async () => {
+  const request: ReadyFetch = async () => ({
+    ok: false,
+    status: 404,
+    json: async () => ({ ok: false }),
+  })
+
+  await assert.rejects(
+    signal_frontend_ready(
+      new URL('http://127.0.0.1:8765/index.html?cap=session-secret'),
+      request,
+    ),
+    /HTTP 404/,
+  )
+})

--- a/frontend/matterviz-viewer/tests/startup.test.ts
+++ b/frontend/matterviz-viewer/tests/startup.test.ts
@@ -51,3 +51,19 @@ test('rejects a failed readiness acknowledgement', async () => {
     /HTTP 404/,
   )
 })
+
+test('rejects readiness when the backend rejects an HTTP 200 acknowledgement', async () => {
+  const request: ReadyFetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: false }),
+  })
+
+  await assert.rejects(
+    signal_frontend_ready(
+      new URL('http://127.0.0.1:8765/index.html?cap=session-secret'),
+      request,
+    ),
+    /MatterViz readiness request was rejected/,
+  )
+})

--- a/tests/matterviz-volume-e2e/src/lib.rs
+++ b/tests/matterviz-volume-e2e/src/lib.rs
@@ -6,6 +6,8 @@ pub mod cli;
 pub mod control_protocol;
 #[path = "../../../frontend/matterviz-desktop/src/control_transport.rs"]
 pub mod control_transport;
+#[path = "../../../frontend/matterviz-desktop/src/inherited_pipe.rs"]
+pub mod inherited_pipe;
 #[path = "../../../frontend/matterviz-desktop/src/memory_budget.rs"]
 pub mod memory_budget;
 #[path = "../../../frontend/matterviz-desktop/src/service.rs"]

--- a/tests/matterviz-volume-e2e/src/lib.rs
+++ b/tests/matterviz-volume-e2e/src/lib.rs
@@ -14,6 +14,8 @@ pub mod memory_budget;
 pub mod service;
 #[path = "../../../frontend/matterviz-desktop/src/session_data.rs"]
 pub mod session_data;
+#[path = "../../../frontend/matterviz-desktop/src/shutdown.rs"]
+pub mod shutdown;
 #[path = "../../../frontend/matterviz-desktop/src/stream_broker.rs"]
 pub mod stream_broker;
 #[path = "../../../frontend/matterviz-desktop/src/transport.rs"]


### PR DESCRIPTION
## Root cause

Several independent lifecycle and transport assumptions could make the MatterViz desktop runtime hang, report a false startup success, or lose protocol errors:

- inherited pipe handles could remain open in WebView helper processes
- one shared control lock allowed `Return` to wait behind an active calculation
- bootstrap used one coarse timeout instead of separate transfer and frontend-readiness stages
- the frontend inferred readiness from page loading rather than an authenticated readiness signal
- malformed backend replies could pass through as HTTP 200 responses

## Fix

- mark adopted control and volume descriptors close-on-exec before helper processes launch
- split control request writes from response coordination so `Return` remains responsive while a calculation is pending
- enforce independent initial-transfer, server-startup, and frontend-readiness deadlines
- require an explicit capability-authenticated frontend readiness POST
- reject malformed control results and terminate the invalid session
- avoid the deprecated macOS `libc::mach_host_self` binding without changing the underlying Mach call
- add regression coverage for the affected startup, transport, timeout, and concurrency paths

No root-level Fortran, `ext/`, `libreta_hybrid/`, or no-GUI calculation-backend behavior changes. No numerical output changes and no new runtime dependencies.

Closes #41
Closes #42
Closes #43
Closes #45
Closes #46

## Verification

- MatterViz desktop Rust tests: 84 passed
- C/Rust volume e2e tests: 85 passed
- frontend Node tests: 119 passed
- Svelte check: 0 errors and 0 warnings
- Python tests: 26 passed
- frontend production build
- desktop and e2e `cargo clippy --locked -- -D warnings`
- `git diff --check`

## Before merge

@Stardust0831 Please confirm the complete Linux, macOS, and Windows CI/package matrix before marking this ready to merge; only the local macOS validation above has been completed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit frontend readiness signaling (desktop + viewer) and a `/api/ready` endpoint so readiness is confirmed beyond page load.
  * Introduced a shared shutdown signal to coordinate termination across desktop workflows.
* **Bug Fixes**
  * Improved inherited pipe/handle adoption with safer descriptor behavior (including close-on-exec) across platforms.
  * Enhanced control-frame timeout/cancellation behavior and tightened validation of control responses.
* **Tests**
  * Updated and added coverage for readiness acceptance/rejection, startup timing, shutdown coordination, and pipe adoption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->