### PR TITLE
Fix MatterViz rendering startup on macOS

### DIFF
--- a/frontend/matterviz-desktop/src/cli.rs
+++ b/frontend/matterviz-desktop/src/cli.rs
@@ -8,6 +8,11 @@ use crate::service::AppConfig;
 use crate::transport::TransportConfig;
 
 const DEFAULT_URL: &str = "http://127.0.0.1:8765/index.html?manifest=/session/manifest.json";
+const DEFAULT_MANAGED_HOST: &str = if cfg!(target_os = "macos") {
+    "localhost"
+} else {
+    "127.0.0.1"
+};
 
 #[derive(Clone, Debug)]
 pub enum FileDialogDestination {
@@ -43,8 +48,8 @@ impl Cli {
         let mut session = None;
         let mut manifest = None;
         let mut state = None;
-        let mut host =
-            std::env::var("MULTIWFN_MATTERVIZ_HOST").unwrap_or_else(|_| "localhost".to_owned());
+        let mut host = std::env::var("MULTIWFN_MATTERVIZ_HOST")
+            .unwrap_or_else(|_| DEFAULT_MANAGED_HOST.to_owned());
         let mut host_arg = false;
         let mut port = match std::env::var("MULTIWFN_MATTERVIZ_PORT") {
             Ok(value) => value
@@ -332,7 +337,7 @@ fn usage() -> String {
 mod tests {
     use std::path::Path;
 
-    use super::{Cli, FileDialogDestination, Mode};
+    use super::{Cli, FileDialogDestination, Mode, DEFAULT_MANAGED_HOST};
 
     #[test]
     fn parses_managed_session_and_defaults_manifest() {
@@ -347,7 +352,7 @@ mod tests {
         let Mode::Managed(config) = cli.mode else {
             panic!("expected managed mode");
         };
-        assert_eq!(config.host, "localhost");
+        assert_eq!(config.host, DEFAULT_MANAGED_HOST);
         assert_eq!(config.port, 0);
     }
 

--- a/frontend/matterviz-desktop/src/cli.rs
+++ b/frontend/matterviz-desktop/src/cli.rs
@@ -44,7 +44,7 @@ impl Cli {
         let mut manifest = None;
         let mut state = None;
         let mut host =
-            std::env::var("MULTIWFN_MATTERVIZ_HOST").unwrap_or_else(|_| "127.0.0.1".to_owned());
+            std::env::var("MULTIWFN_MATTERVIZ_HOST").unwrap_or_else(|_| "localhost".to_owned());
         let mut host_arg = false;
         let mut port = match std::env::var("MULTIWFN_MATTERVIZ_PORT") {
             Ok(value) => value
@@ -344,10 +344,11 @@ mod tests {
             "0".into(),
         ])
         .unwrap();
-        match cli.mode {
-            Mode::Managed(config) => assert_eq!(config.port, 0),
-            Mode::DevUrl(_) => panic!("expected managed mode"),
-        }
+        let Mode::Managed(config) = cli.mode else {
+            panic!("expected managed mode");
+        };
+        assert_eq!(config.host, "localhost");
+        assert_eq!(config.port, 0);
     }
 
     #[test]

--- a/frontend/matterviz-desktop/src/cli.rs
+++ b/frontend/matterviz-desktop/src/cli.rs
@@ -44,18 +44,26 @@ impl Cli {
     where
         I: IntoIterator<Item = String>,
     {
+        Self::parse_with_env(args, |name| std::env::var(name).ok())
+    }
+
+    fn parse_with_env<I, E>(args: I, env_var: E) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = String>,
+        E: Fn(&str) -> Option<String>,
+    {
         let mut frontend = None;
         let mut session = None;
         let mut manifest = None;
         let mut state = None;
-        let mut host = std::env::var("MULTIWFN_MATTERVIZ_HOST")
-            .unwrap_or_else(|_| DEFAULT_MANAGED_HOST.to_owned());
+        let mut host =
+            env_var("MULTIWFN_MATTERVIZ_HOST").unwrap_or_else(|| DEFAULT_MANAGED_HOST.to_owned());
         let mut host_arg = false;
-        let mut port = match std::env::var("MULTIWFN_MATTERVIZ_PORT") {
-            Ok(value) => value
+        let mut port = match env_var("MULTIWFN_MATTERVIZ_PORT") {
+            Some(value) => value
                 .parse()
                 .map_err(|_| "MULTIWFN_MATTERVIZ_PORT must be 0..65535".to_owned())?,
-            Err(_) => 8765_u16,
+            None => 8765_u16,
         };
         let mut port_arg = false;
         let mut url = None;
@@ -139,8 +147,7 @@ impl Cli {
 
         let startup_timeout = startup_timeout
             .or_else(|| {
-                std::env::var("MULTIWFN_MATTERVIZ_STARTUP_TIMEOUT")
-                    .ok()
+                env_var("MULTIWFN_MATTERVIZ_STARTUP_TIMEOUT")
                     .and_then(|value| parse_timeout(&value).ok())
             })
             .unwrap_or_else(|| Duration::from_secs(15));
@@ -216,7 +223,7 @@ impl Cli {
             {
                 return Err("transport pipes require a managed session".to_owned());
             }
-            let url = std::env::var("MATTERVIZ_WEB_URL").unwrap_or_else(|_| DEFAULT_URL.to_owned());
+            let url = env_var("MATTERVIZ_WEB_URL").unwrap_or_else(|| DEFAULT_URL.to_owned());
             validate_url(&url)?;
             return Ok(Self {
                 mode: Mode::DevUrl(url),
@@ -339,9 +346,16 @@ mod tests {
 
     use super::{Cli, FileDialogDestination, Mode, DEFAULT_MANAGED_HOST};
 
+    fn parse<I>(args: I) -> Result<Cli, String>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        Cli::parse_with_env(args, |_| None)
+    }
+
     #[test]
     fn parses_managed_session_and_defaults_manifest() {
-        let cli = Cli::parse([
+        let cli = parse([
             "--frontend".into(),
             "dist".into(),
             "--session=session".into(),
@@ -358,7 +372,7 @@ mod tests {
 
     #[test]
     fn parses_paired_managed_volume_pipes() {
-        let cli = Cli::parse([
+        let cli = parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
@@ -376,7 +390,7 @@ mod tests {
 
     #[test]
     fn parses_paired_control_pipes() {
-        let cli = Cli::parse([
+        let cli = parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
@@ -392,13 +406,13 @@ mod tests {
 
     #[test]
     fn rejects_partial_duplicate_or_nonmanaged_volume_pipes() {
-        assert!(Cli::parse([
+        assert!(parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
@@ -406,7 +420,7 @@ mod tests {
             "--control-read-pipe=43".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
@@ -415,14 +429,14 @@ mod tests {
             "--control-write-pipe=44".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
             "--volume-ack-pipe=41".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--frontend=dist".into(),
             "--session=session".into(),
             "--volume-read-pipe=41".into(),
@@ -430,13 +444,13 @@ mod tests {
             "--volume-ack-pipe=43".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--url=http://127.0.0.1:8765".into(),
             "--volume-read-pipe=41".into(),
             "--volume-ack-pipe=42".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--select-file".into(),
             "--output=x.txt".into(),
             "--control-read-pipe=43".into(),
@@ -447,17 +461,17 @@ mod tests {
 
     #[test]
     fn rejects_non_loopback_http_url() {
-        assert!(Cli::parse(["--url".into(), "http://example.com".into()]).is_err());
+        assert!(parse(["--url".into(), "http://example.com".into()]).is_err());
     }
 
     #[test]
     fn parses_file_dialog_boundary() {
-        let cli = Cli::parse(["--select-file".into(), "--output=x.txt".into()]).unwrap();
+        let cli = parse(["--select-file".into(), "--output=x.txt".into()]).unwrap();
         assert!(matches!(
             cli.file_dialog.map(|args| args.destination),
             Some(FileDialogDestination::Output(path)) if path == Path::new("x.txt")
         ));
-        let cli = Cli::parse(["--select-file".into(), "--result-pipe=41".into()]).unwrap();
+        let cli = parse(["--select-file".into(), "--result-pipe=41".into()]).unwrap();
         assert!(matches!(
             cli.file_dialog.map(|args| args.destination),
             Some(FileDialogDestination::ResultPipe(41))
@@ -466,25 +480,25 @@ mod tests {
 
     #[test]
     fn enforces_file_dialog_destination_and_exclusivity() {
-        assert!(Cli::parse(["--select-file".into()]).is_err());
-        assert!(Cli::parse([
+        assert!(parse(["--select-file".into()]).is_err());
+        assert!(parse([
             "--select-file".into(),
             "--output=x.txt".into(),
             "--result-pipe=41".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--select-file".into(),
             "--output=x.txt".into(),
             "--output=y.txt".into(),
         ])
         .is_err());
-        assert!(Cli::parse([
+        assert!(parse([
             "--select-file".into(),
             "--result-pipe=41".into(),
             "--url=http://127.0.0.1:8765".into(),
         ])
         .is_err());
-        assert!(Cli::parse(["--result-pipe=41".into()]).is_err());
+        assert!(parse(["--result-pipe=41".into()]).is_err());
     }
 }

--- a/frontend/matterviz-desktop/src/service.rs
+++ b/frontend/matterviz-desktop/src/service.rs
@@ -210,7 +210,9 @@ impl HttpService {
             .set_nonblocking(true)
             .map_err(|error| error.to_string())?;
         let address = listener.local_addr().map_err(|error| error.to_string())?;
-        let host = if address.ip().is_unspecified() {
+        let host = if config.host.eq_ignore_ascii_case("localhost") {
+            "localhost".to_owned()
+        } else if address.ip().is_unspecified() {
             config.host.clone()
         } else {
             address.ip().to_string()
@@ -472,6 +474,12 @@ impl ServiceRunner {
         }
     }
     fn handle(&self, mut stream: TcpStream) {
+        // BSD platforms can propagate O_NONBLOCK from the listener to accepted
+        // sockets. Responses use blocking write_all, so restore blocking mode
+        // before serving assets that may be larger than the socket send buffer.
+        if stream.set_nonblocking(false).is_err() {
+            return;
+        }
         let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
         let _ = stream.set_write_timeout(Some(Duration::from_secs(30)));
         let (first, host) = match read_http_request(&mut stream) {
@@ -2228,6 +2236,46 @@ mod tests {
             content_type(std::path::Path::new("parser.wasm")),
             "application/wasm"
         );
+    }
+
+    #[test]
+    fn service_serves_large_frontend_assets_completely() {
+        let root = fixture("large-frontend-asset");
+        let frontend = root.join("frontend");
+        let session = root.join("session");
+        fs::create_dir_all(&frontend).unwrap();
+        fs::create_dir_all(&session).unwrap();
+        fs::write(frontend.join("index.html"), "MatterViz").unwrap();
+        fs::write(session.join("manifest.json"), "{}").unwrap();
+        let asset = vec![0x5a; 2 * 1024 * 1024];
+        fs::write(frontend.join("large.js"), &asset).unwrap();
+
+        let service = HttpService::start(AppConfig {
+            frontend,
+            session,
+            manifest: None,
+            state: None,
+            host: "localhost".to_owned(),
+            port: 0,
+            transport: None,
+        })
+        .unwrap();
+        assert_eq!(
+            Url::parse(service.url()).unwrap().host_str(),
+            Some("localhost")
+        );
+
+        let response = request_bytes(service.url(), "GET", "/large.js");
+        let body_start = response
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .unwrap()
+            + 4;
+        assert_eq!(&response[body_start..], asset);
+
+        service.shutdown();
+        join_service(service);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- use `localhost` for the managed MatterViz page URL while keeping the service bound to loopback
- restore blocking mode on accepted sockets before serving frontend assets
- add regression coverage for the default host and complete 2 MiB asset responses

## Root cause

On macOS, the managed WKWebView launch path did not request the page when it was addressed through the numeric `127.0.0.1` URL, so startup timed out before the frontend could render. In addition, accepted sockets could inherit nonblocking mode from the listener on BSD platforms; `write_all` then stopped near the socket-buffer boundary and truncated the large JavaScript and WASM assets.

## Impact

MatterViz can load its full frontend bundle and reach frontend-ready on macOS, restoring molecular structure rendering instead of returning to the Multiwfn menu after the startup timeout.

## Validation

- `cargo fmt --check`
- `cargo test --locked` — 90 passed
- release build and CMake runtime resource staging
- real `PcG0.fchk` launch: 74 atoms and 86 explicit bonds loaded, manifest and structure requested, `/api/ready` received, and the window remained active beyond the default 15-second startup timeout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local service connectivity across operating systems by refining localhost handling and accepted-socket behavior.
  * Ensured large frontend assets (2 MiB) are served completely without truncation.
  * Fixed hostname formation for localhost scenarios in generated URLs/authority.
  * Updated managed-session default host to be OS-appropriate when no environment override is set.
* **Tests**
  * Made CLI-related tests deterministic and aligned defaults with the new host behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->