### PR TITLE
ci: retire redundant legacy GUI validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type == 'branch') }}
+
 permissions:
   contents: read
 
@@ -55,7 +59,6 @@ jobs:
               ninja --version
               cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_RPATH="\$ORIGIN/lib" -DMULTIWFN_GNU_HOT_OPT_LEVEL=O3 2>&1 | tee configure.log
               cmake --build build --parallel 2 2>&1 | tee build.log
-              bash tests/functional/run_nogui_tests.sh /work/build/Multiwfn_noGUI
               mkdir -p package/Multiwfn_noGUI-Linux/lib dist
               cp build/Multiwfn_noGUI package/Multiwfn_noGUI-Linux/Multiwfn_noGUI
               cp LICENSE.txt package/Multiwfn_noGUI-Linux/LICENSE.txt
@@ -170,11 +173,6 @@ jobs:
             echo "::error::$first_error"
           fi
 
-      - name: Functional tests
-        if: runner.os == 'macOS'
-        run: |
-          bash tests/functional/run_nogui_tests.sh "$PWD/build/Multiwfn_noGUI"
-
       - name: Functional tests on Windows
         if: runner.os == 'Windows'
         shell: msys2 {0}
@@ -227,6 +225,7 @@ jobs:
           done
           find package/Multiwfn_noGUI-Windows -maxdepth 1 -type f -printf '%f\n' | sort
 
+      # Validate the packaged archive with the full suite on the glibc 2.28 baseline.
       - name: Test Linux release candidate in clean glibc 2.28 container
         if: runner.os == 'Linux'
         run: |
@@ -252,6 +251,7 @@ jobs:
           otool -L package/Multiwfn_noGUI-macOS/Multiwfn_noGUI | tee package/Multiwfn_noGUI-macOS/otool.txt
           tar -czf dist/Multiwfn_noGUI-macOS.tar.gz -C package Multiwfn_noGUI-macOS
 
+      # Validate the extracted release archive with the full functional suite.
       - name: Test macOS release candidate
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,32 +88,6 @@ jobs:
           fi
           exit "$status"
 
-      - name: Summarize build failure
-        if: failure()
-        run: |
-          {
-            echo "## Build failure tail"
-            echo
-            echo '```text'
-            tail -n 200 build.log 2>/dev/null || tail -n 200 configure.log 2>/dev/null || tail -n 200 linux-container.log 2>/dev/null || true
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          first_error="$(grep -Eim1 '(^|: )(fatal error|error:|undefined reference|ld:|ninja: build stopped|No match for argument|Unable to find a match|Problem:|No such file)' build.log configure.log linux-container.log 2>/dev/null || true)"
-          if [ -n "$first_error" ]; then
-            echo "::error::$first_error"
-          fi
-
-      - name: Upload Linux failure logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-failure-logs
-          path: |
-            linux-container.log
-            configure.log
-            build.log
-          if-no-files-found: ignore
-
       # Validate the packaged archive with the full suite on the glibc 2.28 baseline.
       - name: Test Linux release candidate in clean glibc 2.28 container
         run: |
@@ -125,7 +99,8 @@ jobs:
             -v "$PWD:/work" \
             -w /work \
             rockylinux:8 \
-            bash tests/functional/run_nogui_tests.sh /work/clean-test/Multiwfn_noGUI-Linux/Multiwfn_noGUI
+            bash tests/functional/run_nogui_tests.sh /work/clean-test/Multiwfn_noGUI-Linux/Multiwfn_noGUI \
+            2>&1 | tee linux-package-test.log
 
       - name: Upload Linux release candidate package
         uses: actions/upload-artifact@v4
@@ -133,6 +108,33 @@ jobs:
           name: Multiwfn_noGUI-package-Linux
           path: dist/Multiwfn_noGUI-Linux.tar.gz
           if-no-files-found: error
+
+      - name: Summarize build failure
+        if: failure()
+        run: |
+          {
+            echo "## Build failure tail"
+            echo
+            echo '```text'
+            tail -n 200 linux-package-test.log 2>/dev/null || tail -n 200 build.log 2>/dev/null || tail -n 200 configure.log 2>/dev/null || tail -n 200 linux-container.log 2>/dev/null || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          first_error="$(grep -Eim1 '(^|: )(fatal error|error:|undefined reference|ld:|ninja: build stopped|No match for argument|Unable to find a match|Problem:|No such file)' linux-package-test.log build.log configure.log linux-container.log 2>/dev/null || true)"
+          if [ -n "$first_error" ]; then
+            echo "::error::$first_error"
+          fi
+
+      - name: Upload Linux failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-failure-logs
+          path: |
+            linux-container.log
+            linux-package-test.log
+            configure.log
+            build.log
+          if-no-files-found: ignore
 
   nogui_macos_gate:
     name: noGUI (macos-latest)
@@ -174,7 +176,10 @@ jobs:
           cp LICENSE.txt release-assets/LICENSE.txt
           cp ATTRIBUTION.txt release-assets/ATTRIBUTION.txt
           cp release-artifacts/Multiwfn_noGUI-Linux.tar.gz release-assets/
-          sha256sum release-assets/* > release-assets/SHA256SUMS.txt
+          (
+            cd release-assets
+            sha256sum ATTRIBUTION.txt LICENSE.txt Multiwfn_noGUI-Linux.tar.gz > SHA256SUMS.txt
+          )
           version="${GITHUB_REF_NAME#v}"
           version="${version%-nogui.*}"
           printf 'Linux headless/noGUI build of Multiwfn %s.\n\n' "$version" > RELEASE_NOTES.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [main, official-build, upstream-tracking]
+    branches: [official-build, upstream-tracking]
     tags: ['v*-nogui.*']
   pull_request:
     branches: [main]
@@ -17,25 +17,18 @@ permissions:
 
 jobs:
   nogui:
-    name: noGUI (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: noGUI (ubuntu-latest)
+    runs-on: ubuntu-latest
     timeout-minutes: 75
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Linux dependencies
-        if: runner.os == 'Linux'
         run: |
           docker version
 
       - name: Build, test, and package Linux in glibc 2.28 container
-        if: runner.os == 'Linux'
         run: |
           set +e
           docker run --rm \
@@ -95,44 +88,8 @@ jobs:
           fi
           exit "$status"
 
-      - name: Install macOS dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install gcc cmake ninja
-          echo "FC=$(ls $(brew --prefix)/bin/gfortran-* | sort -V | tail -n 1)" >> "$GITHUB_ENV"
-
-      - name: Install Windows dependencies
-        if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          install: >-
-            mingw-w64-ucrt-x86_64-gcc-fortran
-            mingw-w64-ucrt-x86_64-cmake
-            mingw-w64-ucrt-x86_64-ninja
-            mingw-w64-ucrt-x86_64-openblas
-
-      - name: Configure and build
-        if: runner.os == 'macOS'
-        run: |
-          set -o pipefail
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release 2>&1 | tee configure.log
-          cmake --build build --parallel 2>&1 | tee build.log
-
-      - name: Configure and build on Windows
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          set -o pipefail
-          test -s "$MINGW_PREFIX/lib/libopenblas.a"
-          ls -l "$MINGW_PREFIX"/lib/libopenblas*
-          ls -l "$MINGW_PREFIX"/lib/libgomp* "$MINGW_PREFIX"/lib/libwinpthread* "$MINGW_PREFIX"/lib/libquadmath* "$MINGW_PREFIX"/lib/libgfortran*
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release 2>&1 | tee configure.log
-          cmake --build build --parallel 2>&1 | tee build.log
-
       - name: Summarize build failure
-        if: failure() && runner.os != 'Windows'
+        if: failure()
         run: |
           {
             echo "## Build failure tail"
@@ -147,7 +104,7 @@ jobs:
           fi
 
       - name: Upload Linux failure logs
-        if: failure() && runner.os == 'Linux'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: linux-failure-logs
@@ -157,77 +114,8 @@ jobs:
             build.log
           if-no-files-found: ignore
 
-      - name: Summarize Windows build failure
-        if: failure() && runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          {
-            echo "## Build failure tail"
-            echo
-            echo '```text'
-            tail -n 200 build.log 2>/dev/null || tail -n 200 configure.log 2>/dev/null || true
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          first_error="$(grep -Eim1 '(^|: )(fatal error|error:|undefined reference|ld:|ninja: build stopped)' build.log configure.log 2>/dev/null || true)"
-          if [ -n "$first_error" ]; then
-            echo "::error::$first_error"
-          fi
-
-      - name: Functional tests on Windows
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          bash tests/functional/run_nogui_tests.sh "$PWD/build/Multiwfn_noGUI.exe"
-
-      - name: Collect Windows runtime DLL dependencies
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          set -euo pipefail
-          mkdir -p package/Multiwfn_noGUI-Windows
-          cp build/Multiwfn_noGUI.exe package/Multiwfn_noGUI-Windows/Multiwfn_noGUI.exe
-          cp LICENSE.txt package/Multiwfn_noGUI-Windows/LICENSE.txt
-          cp ATTRIBUTION.txt package/Multiwfn_noGUI-Windows/ATTRIBUTION.txt
-          cp settings.ini package/Multiwfn_noGUI-Windows/settings.ini
-          : > package/Multiwfn_noGUI-Windows/windows-dlls.log
-          processed=""
-          while :; do
-            changed=0
-            for binary in package/Multiwfn_noGUI-Windows/Multiwfn_noGUI.exe package/Multiwfn_noGUI-Windows/*.dll; do
-              [ -e "$binary" ] || continue
-              case " $processed " in
-                *" $binary "*) continue ;;
-              esac
-              processed="$processed $binary"
-              objdump -p "$binary" | tee -a package/Multiwfn_noGUI-Windows/windows-dlls.log
-              for dll in $(objdump -p "$binary" | awk '/DLL Name:/ {print $3}'); do
-                case "$dll" in
-                  KERNEL32.dll|msvcrt.dll|USER32.dll|ADVAPI32.dll|SHELL32.dll|WS2_32.dll|bcrypt.dll|api-ms-win-*.dll)
-                    ;;
-                  *)
-                    dll_path="$(command -v "$dll" || true)"
-                    if [ -z "$dll_path" ] && [ -f "$MINGW_PREFIX/bin/$dll" ]; then
-                      dll_path="$MINGW_PREFIX/bin/$dll"
-                    fi
-                    if [ -z "$dll_path" ]; then
-                      echo "::error::Could not locate runtime DLL $dll"
-                      exit 1
-                    fi
-                    if [ ! -f "package/Multiwfn_noGUI-Windows/$dll" ]; then
-                      cp "$dll_path" package/Multiwfn_noGUI-Windows/
-                      changed=1
-                    fi
-                    ;;
-                esac
-              done
-            done
-            [ "$changed" -eq 1 ] || break
-          done
-          find package/Multiwfn_noGUI-Windows -maxdepth 1 -type f -printf '%f\n' | sort
-
       # Validate the packaged archive with the full suite on the glibc 2.28 baseline.
       - name: Test Linux release candidate in clean glibc 2.28 container
-        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           rm -rf clean-test
@@ -239,66 +127,28 @@ jobs:
             rockylinux:8 \
             bash tests/functional/run_nogui_tests.sh /work/clean-test/Multiwfn_noGUI-Linux/Multiwfn_noGUI
 
-      - name: Package macOS release candidate
-        if: runner.os == 'macOS'
-        run: |
-          set -euo pipefail
-          mkdir -p package/Multiwfn_noGUI-macOS dist
-          cp build/Multiwfn_noGUI package/Multiwfn_noGUI-macOS/Multiwfn_noGUI
-          cp LICENSE.txt package/Multiwfn_noGUI-macOS/LICENSE.txt
-          cp ATTRIBUTION.txt package/Multiwfn_noGUI-macOS/ATTRIBUTION.txt
-          cp settings.ini package/Multiwfn_noGUI-macOS/settings.ini
-          otool -L package/Multiwfn_noGUI-macOS/Multiwfn_noGUI | tee package/Multiwfn_noGUI-macOS/otool.txt
-          tar -czf dist/Multiwfn_noGUI-macOS.tar.gz -C package Multiwfn_noGUI-macOS
-
-      # Validate the extracted release archive with the full functional suite.
-      - name: Test macOS release candidate
-        if: runner.os == 'macOS'
-        run: |
-          set -euo pipefail
-          rm -rf clean-test
-          mkdir clean-test
-          tar -xzf dist/Multiwfn_noGUI-macOS.tar.gz -C clean-test
-          bash tests/functional/run_nogui_tests.sh "$PWD/clean-test/Multiwfn_noGUI-macOS/Multiwfn_noGUI"
-
-      - name: Package Windows release candidate
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force dist | Out-Null
-          Compress-Archive -Path package/Multiwfn_noGUI-Windows/* -DestinationPath dist/Multiwfn_noGUI-Windows.zip -Force
-
-      - name: Test Windows release candidate outside MSYS2
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          Remove-Item -Recurse -Force clean-test -ErrorAction SilentlyContinue
-          Expand-Archive dist/Multiwfn_noGUI-Windows.zip -DestinationPath clean-test
-          $env:Path = (($env:Path -split ';') | Where-Object { $_ -notmatch 'msys64' }) -join ';'
-          $work = Join-Path $PWD "clean-test-work"
-          Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Force $work | Out-Null
-          @"
-          3
-          water
-          O 0 0 0
-          H 0 0 0.96
-          H 0.92 0 -0.24
-          "@ | Set-Content -Path "$work/water.xyz" -Encoding ascii
-          "26`n1`n`nq`n0`nq`n" | & "$PWD/clean-test/Multiwfn_noGUI.exe" "$work/water.xyz" > "$work/geometry.out"
-          Select-String -Path "$work/geometry.out" -SimpleMatch "Formula: H2 O1" | Out-Null
-          Select-String -Path "$work/geometry.out" -SimpleMatch "Geometry center (X/Y/Z):    0.30666667    0.00000000    0.24000000 Angstrom" | Out-Null
-
-      - name: Upload release candidate package
+      - name: Upload Linux release candidate package
         uses: actions/upload-artifact@v4
         with:
-          name: Multiwfn_noGUI-package-${{ runner.os }}
-          path: |
-            dist/Multiwfn_noGUI-Linux.tar.gz
-            dist/Multiwfn_noGUI-macOS.tar.gz
-            dist/Multiwfn_noGUI-Windows.zip
+          name: Multiwfn_noGUI-package-Linux
+          path: dist/Multiwfn_noGUI-Linux.tar.gz
           if-no-files-found: error
+
+  nogui_macos_gate:
+    name: noGUI (macos-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Confirm unified MatterViz packaging
+        run: echo "macOS platform-specific noGUI builds are replaced by unified MatterViz packages; this required check is intentionally lightweight."
+
+  nogui_windows_gate:
+    name: noGUI (windows-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Confirm unified MatterViz packaging
+        run: echo "Windows platform-specific noGUI builds are replaced by unified MatterViz packages; this required check is intentionally lightweight."
 
   release:
     name: Release
@@ -311,9 +161,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download binaries
+      - name: Download Linux binary artifact
         uses: actions/download-artifact@v4
         with:
+          name: Multiwfn_noGUI-package-Linux
           path: release-artifacts
 
       - name: Package release assets
@@ -322,36 +173,33 @@ jobs:
           mkdir -p release-assets
           cp LICENSE.txt release-assets/LICENSE.txt
           cp ATTRIBUTION.txt release-assets/ATTRIBUTION.txt
-          cp release-artifacts/Multiwfn_noGUI-package-Linux/Multiwfn_noGUI-Linux.tar.gz release-assets/
-          cp release-artifacts/Multiwfn_noGUI-package-macOS/Multiwfn_noGUI-macOS.tar.gz release-assets/
-          cp release-artifacts/Multiwfn_noGUI-package-Windows/Multiwfn_noGUI-Windows.zip release-assets/
+          cp release-artifacts/Multiwfn_noGUI-Linux.tar.gz release-assets/
           sha256sum release-assets/* > release-assets/SHA256SUMS.txt
           version="${GITHUB_REF_NAME#v}"
           version="${version%-nogui.*}"
-          printf 'Cross-platform noGUI build of Multiwfn %s.\n\n' "$version" > RELEASE_NOTES.md
+          printf 'Linux headless/noGUI build of Multiwfn %s.\n\n' "$version" > RELEASE_NOTES.md
           cat >> RELEASE_NOTES.md <<'EOF'
-          This release keeps the upstream Fortran source behavior and adds a minimal CMake/GitHub Actions build path for noGUI binaries.
-          The Multiwfn license and this repository's supplemental attribution are included as LICENSE.txt and ATTRIBUTION.txt in this release and inside each platform archive.
+          This release contains the Linux headless/noGUI binary built from the upstream Fortran source with the minimal CMake/GitHub Actions build path.
+          The Multiwfn license and this repository's supplemental attribution are included as LICENSE.txt and ATTRIBUTION.txt in this release and inside the Linux archive.
 
           Validation in CI:
-          - Linux, macOS, and Windows release-candidate packages built with GNU Fortran.
-          - Linux package built on a glibc 2.28 Rocky Linux 8 baseline, then extracted and tested in a clean Rocky Linux 8 container without installing BLAS/LAPACK.
-          - Windows zip extracted and smoke-tested outside the MSYS2 shell, with required MSYS2 runtime DLLs copied beside the executable.
+          - Linux package built with GNU Fortran on a glibc 2.28 Rocky Linux 8 baseline.
+          - Extracted Linux package tested in a clean Rocky Linux 8 container without installing BLAS/LAPACK.
           - Geometry-only XYZ loading and structure analysis workflow.
           - Gaussian cube loading, grid statistics, and cube export workflow.
 
           Notes:
-          - These are noGUI binaries; DISLIN/Motif GUI support is intentionally outside this release.
+          - This is a noGUI binary; DISLIN/Motif GUI support is intentionally outside this release.
           - Fractional-derivative support is disabled in the default CI build.
+          - Unified MatterViz packages provide the supported cross-platform distribution.
 
-          Acknowledgements:
-          - Thanks to @bane-dysta for contributing the Windows executable icon in PR #2.
           EOF
 
       - name: Verify license packaging
         run: |
           set -euo pipefail
           test -s LICENSE.txt
+          test -s ATTRIBUTION.txt
           test -s release-assets/LICENSE.txt
           test -s release-assets/ATTRIBUTION.txt
           cmp LICENSE.txt release-assets/LICENSE.txt
@@ -359,12 +207,6 @@ jobs:
           tar -tzf release-assets/Multiwfn_noGUI-Linux.tar.gz | grep -Fx Multiwfn_noGUI-Linux/LICENSE.txt
           tar -tzf release-assets/Multiwfn_noGUI-Linux.tar.gz | grep -Fx Multiwfn_noGUI-Linux/ATTRIBUTION.txt
           tar -tzf release-assets/Multiwfn_noGUI-Linux.tar.gz | grep -Fx Multiwfn_noGUI-Linux/settings.ini
-          tar -tzf release-assets/Multiwfn_noGUI-macOS.tar.gz | grep -Fx Multiwfn_noGUI-macOS/LICENSE.txt
-          tar -tzf release-assets/Multiwfn_noGUI-macOS.tar.gz | grep -Fx Multiwfn_noGUI-macOS/ATTRIBUTION.txt
-          tar -tzf release-assets/Multiwfn_noGUI-macOS.tar.gz | grep -Fx Multiwfn_noGUI-macOS/settings.ini
-          unzip -Z1 release-assets/Multiwfn_noGUI-Windows.zip | grep -Fx LICENSE.txt
-          unzip -Z1 release-assets/Multiwfn_noGUI-Windows.zip | grep -Fx ATTRIBUTION.txt
-          unzip -Z1 release-assets/Multiwfn_noGUI-Windows.zip | grep -Fx settings.ini
 
       - name: Create GitHub release
         env:
@@ -373,5 +215,5 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           version="${version%-nogui.*}"
           gh release create "$GITHUB_REF_NAME" release-assets/* \
-            --title "Multiwfn ${version} noGUI cross-platform build" \
+            --title "Multiwfn ${version} Linux headless/noGUI build" \
             --notes-file RELEASE_NOTES.md

--- a/.github/workflows/gui-demo-release.yml
+++ b/.github/workflows/gui-demo-release.yml
@@ -2,8 +2,6 @@ name: gui-demo-release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'gui-demo-preview-*'
       - 'gui-qt-preview-*'
@@ -16,10 +14,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: gui-demo-release-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type == 'branch') }}
+
 jobs:
   package:
     name: Package Multiwfn GUI (${{ matrix.platform }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -36,11 +38,16 @@ jobs:
             asset_ext: zip
 
     steps:
+      - name: Pull request compatibility gate
+        if: github.event_name == 'pull_request'
+        run: echo "Legacy Qt/3Dmol packaging is release-only; this check preserves the existing required context."
+
       - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
 
       - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+        if: github.event_name != 'pull_request' && runner.os == 'Linux'
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -63,14 +70,14 @@ jobs:
             libegl1
 
       - name: Install macOS dependencies
-        if: runner.os == 'macOS'
+        if: github.event_name != 'pull_request' && runner.os == 'macOS'
         run: |
           set -euo pipefail
           brew install gcc cmake ninja
           echo "FC=$(ls $(brew --prefix)/bin/gfortran-* | sort -V | tail -n 1)" >> "$GITHUB_ENV"
 
       - name: Install Windows dependencies
-        if: runner.os == 'Windows'
+        if: github.event_name != 'pull_request' && runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
@@ -82,7 +89,7 @@ jobs:
             mingw-w64-ucrt-x86_64-openblas
 
       - name: Build Multiwfn GUI executable
-        if: runner.os != 'Windows'
+        if: github.event_name != 'pull_request' && runner.os != 'Windows'
         run: |
           set -o pipefail
           default_shell="browser"
@@ -110,7 +117,7 @@ jobs:
           echo "MULTIWFN_GUI_EXE=${exe_name}" >> "$GITHUB_ENV"
 
       - name: Build Multiwfn GUI executable on Windows
-        if: runner.os == 'Windows'
+        if: github.event_name != 'pull_request' && runner.os == 'Windows'
         shell: msys2 {0}
         run: |
           set -o pipefail
@@ -133,7 +140,7 @@ jobs:
           echo "MULTIWFN_GUI_EXE=${exe_name}" >> "$GITHUB_ENV"
 
       - name: Verify cube coordinate units
-        if: runner.os != 'Windows'
+        if: github.event_name != 'pull_request' && runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
@@ -141,7 +148,7 @@ jobs:
           tests/functional/run_3dmol_cube_unit_test.sh "build-3dmol-gui/${MULTIWFN_GUI_EXE}"
 
       - name: Build Qt native launcher
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.ref_name == 'main' || startsWith(github.ref_name, 'gui-qt-preview-') || contains(github.ref_name, '-gui.')
+        if: github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'main' || startsWith(github.ref_name, 'gui-qt-preview-') || contains(github.ref_name, '-gui.'))
         shell: bash
         run: |
           set -euo pipefail
@@ -159,7 +166,7 @@ jobs:
             frontend/qt-multiwfn-gui/qt_multiwfn_gui.py
 
       - name: Summarize build failure
-        if: failure()
+        if: github.event_name != 'pull_request' && failure()
         shell: bash
         run: |
           {
@@ -175,6 +182,7 @@ jobs:
           fi
 
       - name: Prepare common package files
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -213,7 +221,7 @@ jobs:
           fi
 
       - name: Package Linux demo
-        if: runner.os == 'Linux'
+        if: github.event_name != 'pull_request' && runner.os == 'Linux'
         shell: bash
         run: |
           set -euo pipefail
@@ -234,7 +242,7 @@ jobs:
           tar -czf "dist/${PKG}.tar.gz" -C package "$PKG"
 
       - name: Package macOS demo
-        if: runner.os == 'macOS'
+        if: github.event_name != 'pull_request' && runner.os == 'macOS'
         shell: bash
         run: |
           set -euo pipefail
@@ -256,7 +264,7 @@ jobs:
           tar -czf "dist/${PKG}.tar.gz" -C package "$PKG"
 
       - name: Package Windows demo
-        if: runner.os == 'Windows'
+        if: github.event_name != 'pull_request' && runner.os == 'Windows'
         shell: msys2 {0}
         run: |
           set -euo pipefail
@@ -299,13 +307,14 @@ jobs:
           find "package/${PKG}" -maxdepth 2 -type f | sort
 
       - name: Create Windows zip
-        if: runner.os == 'Windows'
+        if: github.event_name != 'pull_request' && runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force dist | Out-Null
           Compress-Archive -Path "package/$env:PKG/*" -DestinationPath "dist/$env:PKG.zip" -Force
 
       - name: Verify attribution in GUI archive
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -318,6 +327,7 @@ jobs:
           fi
 
       - name: Upload GUI package
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: multiwfn-gui-package-${{ matrix.platform }}

--- a/.github/workflows/gui-linux-compat.yml
+++ b/.github/workflows/gui-linux-compat.yml
@@ -20,10 +20,16 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Pull request compatibility gate
+        if: github.event_name == 'pull_request'
+        run: echo "GUI Linux glibc 2.28 compatibility build is reserved for manual runs."
+
       - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
 
       - name: Build GUI package in Rocky Linux 8
+        if: github.event_name != 'pull_request'
         run: |
           set +e
           docker run --rm \
@@ -208,6 +214,7 @@ jobs:
           exit "$status"
 
       - name: Test GUI package in clean Rocky Linux 8
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           rm -rf clean-gui-test
@@ -319,7 +326,7 @@ jobs:
             '
 
       - name: Upload compatibility logs
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: multiwfn-gui-linux-glibc228-logs
@@ -330,7 +337,7 @@ jobs:
           retention-days: 7
 
       - name: Upload compatibility package
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name != 'pull_request' && github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: multiwfn-gui-linux-glibc228

--- a/docs/matterviz-spectrum-log.md
+++ b/docs/matterviz-spectrum-log.md
@@ -23,6 +23,10 @@
 - Removed heavyweight noGUI validation on `main` pushes. Pull requests provide
   the pre-merge build/test gate, while release tags rebuild and test their own
   same-run Linux artifact; this avoids the former PR/main/tag triple build.
+- Final review kept the intentional no-`main` trigger, corrected release
+  checksum entries to use downloadable asset basenames, and moved failure
+  diagnostics after the extracted-package suite while preserving its output in
+  an uploaded log.
 - Kept release artifact provenance unchanged: every tag still builds and tests
   its platform packages in the publishing workflow, and the release job reuses
   only artifacts from that same workflow run. Cross-run PR artifact promotion

--- a/docs/matterviz-spectrum-log.md
+++ b/docs/matterviz-spectrum-log.md
@@ -11,9 +11,18 @@
   names so the current ruleset cannot strand open PRs; `main` pushes no longer
   build the retired GUI.
 - Added cancellation for superseded noGUI and legacy GUI runs. Linux and macOS
-  noGUI now run the full functional suite only against the extracted release
-  package, eliminating the earlier duplicate run against the unpackaged binary;
-  Windows retains both its full suite and the distinct outside-MSYS2 smoke test.
+  noGUI initially retained extracted-package testing while removing duplicate
+  pre-package runs. The follow-up scope decision then removed separate macOS and
+  Windows noGUI builds entirely: their supported distributions are the unified
+  MatterViz packages, which already exercise command-line startup and analysis.
+- The remaining noGUI workflow is Linux-only. It builds on Rocky Linux 8,
+  verifies the glibc 2.28 floor, tests the extracted archive with the full
+  functional suite, and publishes only the Linux headless tarball for
+  `v*-nogui.*`. Pull requests retain lightweight macOS/Windows noGUI contexts
+  only because the active ruleset still requires those exact historical names.
+- Removed heavyweight noGUI validation on `main` pushes. Pull requests provide
+  the pre-merge build/test gate, while release tags rebuild and test their own
+  same-run Linux artifact; this avoids the former PR/main/tag triple build.
 - Kept release artifact provenance unchanged: every tag still builds and tests
   its platform packages in the publishing workflow, and the release job reuses
   only artifacts from that same workflow run. Cross-run PR artifact promotion

--- a/docs/matterviz-spectrum-log.md
+++ b/docs/matterviz-spectrum-log.md
@@ -1,5 +1,30 @@
 # MatterViz parity development log
 
+## 2026-07-25: CI streamlining
+
+- Audited all nine workflows and the active `main` ruleset. Ordinary PRs were
+  required to build noGUI on three platforms, the retired Qt/3Dmol GUI on three
+  platforms, and the retired GUI again on Rocky Linux 8; MatterViz changes added
+  another Linux validation job and three-platform package matrix.
+- Restricted actual Qt/3Dmol builds to their existing manual and legacy-tag
+  release paths. Pull requests retain cheap jobs with the exact required check
+  names so the current ruleset cannot strand open PRs; `main` pushes no longer
+  build the retired GUI.
+- Added cancellation for superseded noGUI and legacy GUI runs. Linux and macOS
+  noGUI now run the full functional suite only against the extracted release
+  package, eliminating the earlier duplicate run against the unpackaged binary;
+  Windows retains both its full suite and the distinct outside-MSYS2 smoke test.
+- Kept release artifact provenance unchanged: every tag still builds and tests
+  its platform packages in the publishing workflow, and the release job reuses
+  only artifacts from that same workflow run. Cross-run PR artifact promotion
+  remains deliberately unsupported.
+- Deferred MatterViz-internal frontend/Rust/Linux build deduplication until the
+  prerelease updater workflow PR is merged, avoiding conflicting edits to the
+  same workflow and preserving its preview/formal build distinction. Local
+  verification passes `actionlint` 1.7.12 for all changed workflows, static
+  event-routing assertions, 18/18 existing MatterViz build-contract tests and
+  `git diff --check`; independent review found no remaining important issue.
+
 ## 2026-07-14: Native Rust host migration started
 
 - Corrected the implementation direction after the Python launcher fixes became a second process-lifecycle layer: MatterViz will use one native Rust host for the local HTTP/session service, WebView creation, API routing, native file selection, port binding and shutdown. Fortran remains the tightly coupled Multiwfn calculation adapter and continues to own the existing request loop; no calculation core was changed.

--- a/docs/matterviz-spectrum-todo.md
+++ b/docs/matterviz-spectrum-todo.md
@@ -11,11 +11,17 @@ Updated: 2026-07-25
 - [x] Cancel superseded noGUI and legacy GUI workflow runs for the same PR/ref.
 - [x] Remove duplicate pre-package Linux/macOS noGUI functional runs while
   retaining the stronger extracted-package full suites and Windows coverage.
+- [x] Stop compiling separate Windows/macOS noGUI binaries. Preserve their
+  current required-check names as lightweight gates while the unified MatterViz
+  packages retain platform command-line smoke coverage.
+- [x] Make noGUI CI and `v*-nogui.*` releases Linux-only, keep the Rocky Linux 8
+  glibc 2.28 package/full-suite gate, and remove heavyweight `main` push reruns.
 - [ ] After PR #51 merges, deduplicate the final MatterViz workflow: build the
   platform-independent frontend once, keep platform-native tests in the package
   matrix, and remove the duplicate standalone Linux release/CMake build.
 - [ ] After the streamlined workflow is proven on a PR, replace the transitional
-  legacy required contexts in the `main` ruleset with current stable CI gates.
+  legacy/noGUI macOS/noGUI Windows contexts in the `main` ruleset with current
+  stable MatterViz and Linux-headless gates.
 
 ## 2026-07-14 Rust host migration
 

--- a/docs/matterviz-spectrum-todo.md
+++ b/docs/matterviz-spectrum-todo.md
@@ -1,6 +1,21 @@
 # MatterViz origin/main parity TODO
 
-Updated: 2026-07-16
+Updated: 2026-07-25
+
+## 2026-07-25 CI streamlining
+
+- [x] Stop compiling and packaging the retired Qt/3Dmol GUI on ordinary pull
+  requests and `main` pushes; retain complete manual and legacy-tag builds.
+- [x] Preserve the existing legacy GUI required-check contexts as lightweight
+  PR compatibility gates until the repository ruleset is migrated separately.
+- [x] Cancel superseded noGUI and legacy GUI workflow runs for the same PR/ref.
+- [x] Remove duplicate pre-package Linux/macOS noGUI functional runs while
+  retaining the stronger extracted-package full suites and Windows coverage.
+- [ ] After PR #51 merges, deduplicate the final MatterViz workflow: build the
+  platform-independent frontend once, keep platform-native tests in the package
+  matrix, and remove the duplicate standalone Linux release/CMake build.
+- [ ] After the streamlined workflow is proven on a PR, replace the transitional
+  legacy required contexts in the `main` ruleset with current stable CI gates.
 
 ## 2026-07-14 Rust host migration
 


### PR DESCRIPTION
## Summary

- stop compiling and packaging the retired Qt/3Dmol GUI on ordinary pull requests and `main` pushes
- preserve existing required legacy GUI contexts as lightweight PR gates until the repository ruleset is migrated
- stop compiling separate macOS/Windows noGUI binaries; preserve their historical required contexts as lightweight Ubuntu gates
- keep the real noGUI build, extracted-package full suite, and `v*-nogui.*` release Linux-only on the Rocky Linux 8/glibc 2.28 baseline
- remove heavyweight noGUI `main` push reruns so the expensive lifecycle is PR validation followed by trusted release-tag rebuilding
- cancel superseded PR/branch validation without allowing tag or manual release runs to cancel each other

## Why

MatterViz is the supported cross-platform distribution and its Windows/macOS packages already exercise command-line startup and analysis. A second platform-specific noGUI compilation repeats the same Multiwfn calculation core without providing a distinct supported runtime. Linux retains a separate headless/noGUI package until a WebKit-independent MatterViz Host is available.

The active `main` ruleset still requires three legacy GUI contexts, Rocky compatibility, and three historical noGUI contexts. Deleting their PR triggers immediately would strand open pull requests. This change keeps those exact names as cheap compatibility gates while performing only the relevant Linux noGUI build.

MatterViz workflow-internal artifact reuse and removal of the historical `feature/matterviz-gui` push trigger remain deferred until PR #51 merges, because that PR owns `.github/workflows/matterviz-gui.yml` and adds the preview/formal updater distinction.

## Event model

- pull request: Linux noGUI build/test plus lightweight historical GUI/noGUI contexts
- push to `main`: no heavyweight legacy GUI or noGUI rebuild
- `v*-nogui.*` tag: fresh Linux noGUI package/test and same-run Linux release publication
- legacy GUI tag/manual dispatch: complete historical GUI package build remains available

## Verification

- `actionlint` 1.7.12 on all changed workflows
- static event-routing, exact-check-name, artifact, release, and release-safe concurrency assertions
- `python3 -m unittest -v tests.test_matterviz_build_names` (18/18)
- `git diff --check`
- two independent read-only reviews, including release/provenance review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added workflow-level concurrency controls to cancel redundant in-flight runs.
  * Streamlined noGUI release to Linux-only packaging/build, with clean glibc 2.28 validation of Linux release candidates.
  * Updated release packaging/upload to include only the Linux headless/noGUI artifact and refreshed release notes/asset naming.
  * Made GUI demo and Linux compatibility workflows more event-aware, restricting PR builds to lightweight compatibility checks and tightening triggers/uploads.

* **Documentation**
  * Updated MatterViz CI streamlining logs and TODO checklist with remaining follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->