### PR TITLE
Sync official Multiwfn 2026.9.13 source

### DIFF
--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.7.11_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.7.11_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.7.15_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.7.15_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "d1249521e8ccf6c621697f31946561ea962620022b6a20a50a092ef9305c0aa5"
+  "sha256": "be446abd8ab6c079a22fe42bcc93e201f514530718537ec3ec38795f08dad8da"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.7.10_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.7.10_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.7.11_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.7.11_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "36cf331bc5350d87f67777ef2e399908cf916cc413afa78b6eb75956eff78c9f"
+  "sha256": "d1249521e8ccf6c621697f31946561ea962620022b6a20a50a092ef9305c0aa5"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.8.31_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.31_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.9.1_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.9.1_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "8c516cbb7da9429e7c097f178dd38d6ed8524038590c09025558bcfe41546b76"
+  "sha256": "e4bca71ee45b62a68478a1d865c0a1794aecb352cdd851b47116a00dea87667e"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.8.19_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.19_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.8.21_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.21_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "959863d873797cd347a3abf94c817e1bfd93af3c2e1575b45b604e6114140534"
+  "sha256": "ccb06dd48ca0baca17ab37c8547b6c09a700da0140f43f9dafc492f3fc493042"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.8.21_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.21_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.8.28_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.28_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "ccb06dd48ca0baca17ab37c8547b6c09a700da0140f43f9dafc492f3fc493042"
+  "sha256": "a2daefb779e94aef08b9d29a0aa41119631a4adfee8be9793da1232de7b4c60b"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.8.28_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.28_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.8.31_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.31_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "a2daefb779e94aef08b9d29a0aa41119631a4adfee8be9793da1232de7b4c60b"
+  "sha256": "8c516cbb7da9429e7c097f178dd38d6ed8524038590c09025558bcfe41546b76"
 }

--- a/.multiwfn-upstream-manifest.json
+++ b/.multiwfn-upstream-manifest.json
@@ -1,6 +1,6 @@
 {
-  "archive_name": "Multiwfn_2026.7.15_src_Linux.zip",
-  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.7.15_src_Linux.zip",
+  "archive_name": "Multiwfn_2026.8.19_src_Linux.zip",
+  "archive_url": "http://sobereva.com/multiwfn/misc/Multiwfn_2026.8.19_src_Linux.zip",
   "files": [
     "0123dim.f90",
     "AdNDP.f90",
@@ -77,5 +77,5 @@
     "util.f90",
     "visweak.f90"
   ],
-  "sha256": "be446abd8ab6c079a22fe42bcc93e201f514530718537ec3ec38795f08dad8da"
+  "sha256": "959863d873797cd347a3abf94c817e1bfd93af3c2e1575b45b604e6114140534"
 }

--- a/0123dim.f90
+++ b/0123dim.f90
@@ -371,7 +371,7 @@ do while(.true.)
 	if (icurve_vertlinex==1) write(*,*) "4 Delete the vertical line"
 	write(*,"(' 5 Change the ratio of X and Y length, current:',f10.5)") curvexyratio
 	write(*,"(' 6 Find the positions of local minimum and maximum')")
-	write(*,"(' 7 Find the positions where function value equals to specified value')")
+	write(*,"(' 7 Find the positions where function value equals specified value')")
 	if (ilog10y==0) write(*,*) "8 Use logarithmic scaling of Y axis"
 	if (ilog10y==1) write(*,*) "8 Use linear scaling of Y axis"
 	write(*,"(a,a)") " 9 Change the line color, current: ",trim(colorname(iclrcurve))

--- a/CDA.f90
+++ b/CDA.f90
@@ -123,7 +123,7 @@ do ifrag=0,nCDAfrag !Here we first gather basic information of complex(ifrag=0) 
 				exit
 			end if
 		end do
-		call loclabel(10,"NBsUse=",ifound,0) !NbsUse always equals to the actual number of MOs
+		call loclabel(10,"NBsUse=",ifound,0) !NbsUse always equals the actual number of MOs
 		read(10,*) c80tmp,nmoCDA(ifrag)
 		if (nmoCDA(ifrag)/=nbasistmp) then
 			write(*,"(a)") " Error: The number of basis functions is unequal to the number of orbitals! Some basis functions may be &

--- a/CDA.f90
+++ b/CDA.f90
@@ -1104,8 +1104,14 @@ do while(.true.)
 			else if (iorb==0) then
 				exit
 			end if
-			write(*,"(a)") " Set output threshold, e.g. 0.001. If contribution of a pair of fragment orbitals to any of d,b,r is larger than this value then it will be printed."
-			read(*,*) thres
+			write(*,"(a)") " Set output threshold, e.g. 0.001. If contribution of a pair of fragment orbitals to any of d,b,r is larger than this value &
+            &then it will be printed. If pressing ENTER button directly, 0.001 will be used"
+			read(*,"(a)") c80tmp
+            if (c80tmp==" ") then
+                thres=0.001D0
+            else
+				read(c80tmp,*) thres
+            end if
 			if (iout==10) open(iout,file="CDA.txt",status="replace")
 			write(*,"(' Occupation number of orbital',i6,' of the complex:',f12.8)") iorb,occCDA(iorb,0)
 			if (iopshCDA==0) refocc=2D0 !Reference orbital occupation number

--- a/DOS.f90
+++ b/DOS.f90
@@ -112,7 +112,7 @@ call setfil("dislin."//trim(graphformat))
 ireadgautype=1
 if (ifiletype==0) then
 	!Read energy level information from text file, the first number in first row define how many energy levels
-	!in there, the second number in first row if equals to 1, means below data are only energies, if equals to 2,
+	!in there, the second number in first row if equals 1, means below data are only energies, if equals 2,
 	!means both strength and FWHM also present.
 	open(10,file=filename,status="old")
 	call loclabel(10,"Gaussian, Inc",igauout,maxline=100)

--- a/EDA.f90
+++ b/EDA.f90
@@ -686,7 +686,7 @@ write(*,"(a,f16.6,' Hartree')") " E_electrostatic:",E_elst
 write(*,"(a,f16.6,' Hartree')") " E_quantum:      ",E_quan
 write(*,"(/,a,f16.6,' Hartree')") " E_total:        ",E_tot
 
-!I found for G16 A.03 with M06-2X, the E_tot shown above, which is exactly equals to "ETot=" printed by L608, is remarkably
+!I found for G16 A.03 with M06-2X, the E_tot shown above, which is exactly equal to "ETot=" printed by L608, is remarkably
 !different to the single point energy printed in either output file or fch file. By comparing with G09, I found the reason is
 !that the "Ec=" shown by G16 with M06-2X is incorrect
 !Same problem was found for G03 E.01+B3LYP and G16 A.03+B3LYP, while G09 D.01 works normally with B3LYP and M06-2X

--- a/GUI.f90
+++ b/GUI.f90
@@ -102,8 +102,8 @@ call wgapp(idisorbinfomenu,"Show all",idisorbinfo)
 if ((wfntype==0.or.wfntype==1.or.wfntype==2).and.allocated(CObasa)) then
 	call wgapp(idisorbinfomenu,"Show up to LUMO+10",idisorbinfo2)
 	call wgapp(idisorbinfomenu,"Show occupied orbitals",idisorbinfo3)
-else if (allocated(MOocc).and.MOocc(nmo)==0) then
-	call wgapp(idisorbinfomenu,"Show occupied orbitals",idisorbinfo3)
+else if (allocated(MOocc)) then
+    if (MOocc(nmo)==0) call wgapp(idisorbinfomenu,"Show occupied orbitals",idisorbinfo3)
 end if
 CALL WGPOP(idiswindow," Isosur#1 style",idisisosur1style)
 call wgapp(idisisosur1style,"Use solid face",idisisosur1solid)
@@ -258,8 +258,8 @@ call SWGCBK(idisorbinfo,showorbinfo1)
 if ((wfntype==0.or.wfntype==1.or.wfntype==2).and.allocated(CObasa)) then
 	call SWGCBK(idisorbinfo2,showorbinfo2)
 	call SWGCBK(idisorbinfo3,showorbinfo3)
-else if (allocated(MOocc).and.MOocc(nmo)==0) then
-	call SWGCBK(idisorbinfo3,showorbinfo3)
+else if (allocated(MOocc)) then
+	if (MOocc(nmo)==0) call SWGCBK(idisorbinfo3,showorbinfo3)
 end if
 call SWGCBK(idisisosur1solid,setisosur1solid) !Set style for isosur 1
 call SWGCBK(idisisosur1mesh,setisosur1line)
@@ -472,6 +472,7 @@ else if (iallowsetstyle==2) then
 	call wgapp(idisisosurallstyle,"Use points",idisisosurallpoint)
 	call wgapp(idisisosurallstyle,"Use solid face+mesh",idisisosurallsolidmesh)
 	call wgapp(idisisosurallstyle,"Use transparent face",idisisosuralltpr)
+	call wgapp(idisisosurallstyle,"Exchange colors of the two grid data",idisisosurallinvclr)
 end if
 CALL WGPOP(idiswindow,"Set view",idissetpersp)
 CALL wgapp(idissetpersp,"Set rotation of viewpoint",idissetangle)
@@ -567,6 +568,7 @@ else if (iallowsetstyle==2) then
 	call SWGCBK(idisisosurallpoint,setisosurallpoint)
 	call SWGCBK(idisisosurallsolidmesh,setisosurallsolidmesh)
 	call SWGCBK(idisisosuralltpr,setisosuralltpr)
+	call SWGCBK(idisisosurallinvclr,setisosurallinvclr)
 end if
 call SWGCBK(idissetangle,setviewangle)
 call SWGCBK(idissetcamrot,setcamrot)
@@ -2590,6 +2592,52 @@ read(inpstring,*) opacitycub2
 call drawmol
 CALL SWGWTH(20) !Recover default
 end subroutine
+
+
+!Exchange colors of two grid data
+subroutine setisosurallinvclr(id)
+integer,intent (in) :: id
+clrRcub2same_old=clrRcub2same
+clrGcub2same_old=clrGcub2same
+clrBcub2same_old=clrBcub2same
+clrRcub2same=clrRcub1same
+clrGcub2same=clrGcub1same
+clrBcub2same=clrBcub1same
+clrRcub1same=clrRcub2same_old
+clrGcub1same=clrGcub2same_old
+clrBcub1same=clrBcub2same_old
+clrRcub2oppo_old=clrRcub2oppo
+clrGcub2oppo_old=clrGcub2oppo
+clrBcub2oppo_old=clrBcub2oppo
+clrRcub2oppo=clrRcub1oppo
+clrGcub2oppo=clrGcub1oppo
+clrBcub2oppo=clrBcub1oppo
+clrRcub1oppo=clrRcub2oppo_old
+clrGcub1oppo=clrGcub2oppo_old
+clrBcub1oppo=clrBcub2oppo_old
+
+clrRcub2samemeshpt_old=clrRcub2samemeshpt
+clrGcub2samemeshpt_old=clrGcub2samemeshpt
+clrBcub2samemeshpt_old=clrBcub2samemeshpt
+clrRcub2samemeshpt=clrRcub1samemeshpt
+clrGcub2samemeshpt=clrGcub1samemeshpt
+clrBcub2samemeshpt=clrBcub1samemeshpt
+clrRcub1samemeshpt=clrRcub2samemeshpt_old
+clrGcub1samemeshpt=clrGcub2samemeshpt_old
+clrBcub1samemeshpt=clrBcub2samemeshpt_old
+clrRcub2oppomeshpt_old=clrRcub2oppomeshpt
+clrGcub2oppomeshpt_old=clrGcub2oppomeshpt
+clrBcub2oppomeshpt_old=clrBcub2oppomeshpt
+clrRcub2oppomeshpt=clrRcub1oppomeshpt
+clrGcub2oppomeshpt=clrGcub1oppomeshpt
+clrBcub2oppomeshpt=clrBcub1oppomeshpt
+clrRcub1oppomeshpt=clrRcub2oppomeshpt_old
+clrGcub1oppomeshpt=clrGcub2oppomeshpt_old
+clrBcub1oppomeshpt=clrBcub2oppomeshpt_old
+call drawmol
+end subroutine
+
+
 
 subroutine setlight(id)
 integer,intent (in) :: id

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.7.10 (release date is the same as version name)"
+write(*,*) "Version 2026.7.11 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.7.11 (release date is the same as version name)"
+write(*,*) "Version 2026.7.15 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.8.21 (release date is the same as version name)"
+write(*,*) "Version 2026.8.28 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"
@@ -687,6 +687,7 @@ do while(.true.) !Main loop
 		    write(*,*) "16 Define one or two fragments for special purpose"
             write(*,*) "17 Generate promolecular wavefunction by calculating and combining atomic ones"
             if (allocated(cubmat)) write(*,*) "18 Set box information of grid data as cell information"
+            write(*,*) "19 Load grid data from a cube file (current system is not affected)"
             write(*,*) "88/89 Calculate two-electron integral between for four PGTFs/orbitals"
 		    write(*,*) "90 Calculate nuclear attractive energy between a fragment and an orbital"
 		    write(*,*) "91 Exchange orbital energies and occupations"
@@ -855,7 +856,17 @@ do while(.true.) !Main loop
             else if (i==18) then
 				call grid2cellinfo
                 write(*,*) "Done!"
-                call showcellinfo
+            else if (i==19) then
+				write(*,*) "Input path of .cub file, e.g. D:\test.cub"
+				do while(.true.)
+					read(*,"(a)") c200tmp
+					inquire(file=c200tmp,exist=alive)
+					if (alive) exit
+					write(*,*) "Cannot find the file, input again!"
+				end do
+				call readcube(c200tmp,0,1)
+                write(*,*)
+                write(*,*) "Grid date has been successfully loaded!"
             else if (i==88) then
 				call showGTF_ERI
             else if (i==89) then

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.8.28 (release date is the same as version name)"
+write(*,*) "Version 2026.8.31 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.7.15 (release date is the same as version name)"
+write(*,*) "Version 2026.8.19 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.8.19 (release date is the same as version name)"
+write(*,*) "Version 2026.8.21 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"
@@ -413,7 +413,7 @@ do while(.true.) !Main loop
 		    end if
             iorbvis=0 !Recover its status. iorbvis=0 makes saved image file has DISLIN prefix
             ishowdatarange=0 !Do not show data range if showing it
-            call setfil("dislin."//trim(graphformat)) !The file name of saved image file may have been modified (e.g. equal to orbital index), so recover to default
+            call setfil("dislin."//trim(graphformat)) !The file name of saved image file may have been modified (e.g. equals orbital index), so recover to default
 
             
 	    !!!-------------------------------------------------

--- a/Multiwfn.f90
+++ b/Multiwfn.f90
@@ -36,7 +36,7 @@ call set_color(C_BRIGHT_MAGENTA)
 write(*,*) "Multiwfn -- A Multifunctional Wavefunction Analyzer"
 call reset_color()
 call set_color(C_GREEN)
-write(*,*) "Version 2026.8.31 (release date is the same as version name)"
+write(*,*) "Version 2026.9.1 (release date is the same as version name)"
 call reset_color()
 write(*,*) "Developer: Tian Lu (Beijing Kein Research Center for Natural Sciences)"
 write(*,*) "Multiwfn official website: http://sobereva.com/multiwfn"

--- a/NAONBO.f90
+++ b/NAONBO.f90
@@ -340,7 +340,7 @@ end subroutine
 
 
 !------ Load NAOMO matrix
-!numorb: The number of actual MOs (equals to NBsUse of Gaussian) 
+!numorb: The number of actual MOs (equals NBsUse of Gaussian) 
 subroutine loadNAOMO(numorb)
 use util
 use NAOmod

--- a/atmraddens.f90
+++ b/atmraddens.f90
@@ -17623,7 +17623,7 @@ end subroutine
 !  The atomic wavefunction files are the same as those for generating subroutine genatmraddens
 !  The electron density quality produced by parameters given by this subroutine is evidently not as good as genatmraddens &
 !because the fitting is not pretty accurate, the advantage is that there is no upper limit of distance
-!  The density produced by the STOs is non-negative everywhere, and the integral equals to actual number of electrons
+!  The density produced by the STOs is non-negative everywhere, and the integral equals actual number of electrons
 
 !  Command of Multiwfn used for generating the codes in this subroutine (relative error minimization): 300-2-3-2-0-1-8
 !  I have visually checked fitted density vs. actual density on radial direction
@@ -18900,7 +18900,7 @@ end subroutine
 !  Fitting quality is better than genatmraddens_STOfit, but more expensive due to larger number of GTFs. Simply from Pearson coefficient,&
 !this GTF fitting is seemingly no always better than STO fitting, because nuclear region and tail region is better represented by STO, while&
 !for valence region, the present GTF fitting is always much better
-!  The density produced by the GTFs is non-negative everywhere, and the integral equals to actual number of electrons
+!  The density produced by the GTFs is non-negative everywhere, and the integral equals actual number of electrons
 !
 !  By default, relative error is minimized because I found fitting quality is best in this case. However, for Ar At Bi Bk Cf Cm Es Fe Gd Ir Kr Md Na Ne O Os Pb Po Pt Rn Xe &
 !the fitting is failed (by visualizing fitted radial density) perhaps due to poor initial exponents and coefficients, and H He Mo N also has less satisfactory fitting. So only for them,

--- a/basin.f90
+++ b/basin.f90
@@ -1585,15 +1585,15 @@ do while(.true.)
 	if (iselexttype==2) write(*,"(a)") " -10 Set grid extension distance for mode 1~6, current: Adaptive"
 	if (iselexttype==3) write(*,"(a)") " -10 Set grid extension distance for mode 1~6, current: Detect rho isosurface"
 	if (iselexttype==1.or.iselexttype==2) then
-		write(*,"(a,f4.2,a,i14)") " 1 Low quality grid, spacing=",spclowqual," Bohr, number of grids:    ",ntotlow
-		write(*,"(a,f4.2,a,i14)") " 2 Medium quality grid, spacing=",spcmedqual," Bohr, number of grids: ",ntotmed
-		write(*,"(a,f4.2,a,i14)") " 3 High quality grid, spacing=",spchighqual," Bohr, number of grids:   ",ntothigh
-		write(*,"(a,f4.2,a,i14)") " 4 Lunatic quality grid, spacing=",spclunaqual," Bohr, number of grids:",ntotluna
+		write(*,"(a,f4.2,a,i14)") " 1 Low-quality grid, spacing=",spclowqual," Bohr, number of grids:    ",ntotlow
+		write(*,"(a,f4.2,a,i14)") " 2 Medium-quality grid, spacing=",spcmedqual," Bohr, number of grids: ",ntotmed
+		write(*,"(a,f4.2,a,i14)") " 3 High-quality grid, spacing=",spchighqual," Bohr, number of grids:   ",ntothigh
+		write(*,"(a,f4.2,a,i14)") " 4 Lunatic-quality grid, spacing=",spclunaqual," Bohr, number of grids:",ntotluna
 	else
-		write(*,"(a,f4.2,a,i14)") " 1 Low quality grid, spacing=",spclowqual," Bohr, cost: 1x"
-		write(*,"(a,f4.2,a,i14)") " 2 Medium quality grid, spacing=",spcmedqual," Bohr, cost: 8x"
-		write(*,"(a,f4.2,a,i14)") " 3 High quality grid, spacing=",spchighqual," Bohr, cost: 36x"
-		write(*,"(a,f4.2,a,i14)") " 4 Lunatic quality grid, spacing=",spclunaqual," Bohr, cost: 120x"
+		write(*,"(a,f4.2,a,i14)") " 1 Low-quality grid, spacing=",spclowqual," Bohr, cost: 1x"
+		write(*,"(a,f4.2,a,i14)") " 2 Medium-quality grid, spacing=",spcmedqual," Bohr, cost: 8x"
+		write(*,"(a,f4.2,a,i14)") " 3 High-quality grid, spacing=",spchighqual," Bohr, cost: 36x"
+		write(*,"(a,f4.2,a,i14)") " 4 Lunatic-quality grid, spacing=",spclunaqual," Bohr, cost: 120x"
 	end if
 	write(*,*) "5 Only input grid spacing, automatically set other parameters"
 	write(*,*) "6 Only input the number of points in X,Y,Z, automatically set other parameters"

--- a/basin.f90
+++ b/basin.f90
@@ -626,8 +626,8 @@ do while(.true.)
 		if (allocated(cubmat)) then
 			write(*,"(a)") " Note: There has been a grid data in the memory, please select generating the basins by which manner"
 			write(*,*) "0 Return"
-			write(*,*) "1 Generate the basins by selecting a real space function"
-			write(*,*) "2 Generate the basins by using the grid data stored in memory"
+			write(*,*) "1: Generate the basins by selecting a real space function"
+			write(*,*) "2: Generate the basins by using the grid data stored in memory"
             if (ifiletype==7.or.ifiletype==8) write(*,*) "3: Same as 2, and perform analysis as three-dimension periodic system" !Can be used if grid data is loaded from input file
 			read(*,*) isourcedata
             if (isourcedata==3) then

--- a/bondorder.f90
+++ b/bondorder.f90
@@ -9,9 +9,9 @@ do while(.true.)
 	write(*,*) "           ================ Bond order analysis ==============="
 	if (allocated(b)) then
 		if (allocated(frag1)) then
-			write(*,*) "-1 Redefine fragment 1 and 2 for options 1,3,4,7,8,10"
+			write(*,*) "-1 Redefine fragments 1 and 2 for options 1,3,4,7,8,10"
 		else
-			write(*,*) "-1 Define fragment 1 and 2 for options 1,3,4,7,8,10 (to be defined)"
+			write(*,*) "-1 Define fragments 1 and 2 for options 1,3,4,7,8,10 (to be defined)"
 		end if
 	end if
 	write(*,*) "0 Return"
@@ -454,7 +454,7 @@ real*8,pointer :: ptmat(:,:)
 
 do while(.true.)
 	write(*,*) "Input index of two atom (e.g. 3,5)"
-	write(*,*) "Note: Input 0,0 can return to upper level menu"
+	write(*,*) "Note: Input 0,0 can return to upper-level menu"
 	read(*,*) ind1,ind2
 
 	if (ind1==0.and.ind2==0) exit

--- a/cp2kmate.f90
+++ b/cp2kmate.f90
@@ -80,8 +80,7 @@ integer :: iMDformat=1,nMDsavefreq=1,ioutcube=0,idiagOT=1,imixing=2,ismear=0,iat
 integer :: natmcons=0,nthermoatm=0,ikpoint1=1,ikpoint2=1,ikpoint3=1,nrep1=1,nrep2=1,nrep3=1,ikeepcell=0
 integer,allocatable :: atmcons(:),thermoatm(:)
 real*8 :: efieldvec(3)=0,vacsizex=5/b2a,vacsizey=5/b2a,vacsizez=5/b2a
-real*8 :: frag1chg,frag2chg
-integer :: frag1multi,frag2multi,totalmulti
+integer :: frag1chg,frag2chg,frag1multi,frag2multi,totalmulti
 integer :: iprestype=1,ioutSbas=0,ioutKSbas=0,ioutorbene=0,istate_force=1,idiaglib=1,iGAPW=0,iLSSCF=0,iLRIGPW=0,iPSOLVER=1,niter_evGW=1,niter_scGW0=1,istructfile=0
 real*8 :: Piso=1.01325D0,Ptens(3,3)=reshape( [1.01325D0,0D0,0D0, 0D0,1.01325D0,0D0, 0D0,0D0,1.01325D0], shape=shape(Ptens))
 real*8 :: PBEh_HFX=45

--- a/cp2kmate.f90
+++ b/cp2kmate.f90
@@ -1819,8 +1819,16 @@ if (method=="GFN1-xTB") then
     write(ifileid,"(a)") "        CHECK_ATOMIC_CHARGES F #xTB calculation often crashes without setting this to false"
     write(ifileid,"(a)") "      &END xTB"
 else if (method=="GFN2-xTB") then
+    !Suitable for <=2026.1
+    !write(ifileid,"(a)") "      METHOD xTB"
+    !write(ifileid,"(a)") "      &xTB"
+    !write(ifileid,"(a)") "        &TBLITE"
+    !write(ifileid,"(a)") "          METHOD GFN2"
+    !write(ifileid,"(a)") "        &END TBLITE"
+    !write(ifileid,"(a)") "      &END xTB"
     write(ifileid,"(a)") "      METHOD xTB"
     write(ifileid,"(a)") "      &xTB"
+    write(ifileid,"(a)") "        GFN_TYPE TBLITE"
     write(ifileid,"(a)") "        &TBLITE"
     write(ifileid,"(a)") "          METHOD GFN2"
     write(ifileid,"(a)") "        &END TBLITE"
@@ -2574,6 +2582,12 @@ if (imolden==1.or.ioutSbas==1.or.ioutKSbas==1.or.ioutcube>0.or.iatomcharge>0.or.
     if (imolden==1) then
         write(ifileid,"(a)") "      &MO_MOLDEN #Exporting .molden file containing wavefunction information"
         write(ifileid,"(a)") "        NDIGITS 9 #Output orbital coefficients if absolute value is larger than 1E-9"
+        if (ifPBC==0.or.PBCdir=="NONE") then
+            continue
+        else
+            write(ifileid,"(a)") "        WRITE_CELL T #Write cell information"
+        end if
+        write(ifileid,"(a)") "        WRITE_PSEUDO T #Write number of valence electrons of atoms"
         write(ifileid,"(a)") "      &END MO_MOLDEN"
     end if
     if (iDFTplusU==1) then

--- a/cp2kmate.f90
+++ b/cp2kmate.f90
@@ -3185,7 +3185,7 @@ if (itask==3.or.itask==4.or.itask==5.or.itask==6.or.itask==7.or.itask==8.or.itas
         write(ifileid,"(a)") "    KEEP_ANGLES F #If T, then cell angles will be kepted"
         write(ifileid,"(a)") "    KEEP_SYMMETRY F #If T, then cell symmetry specified by &CELL / SYMMETRY will be kepted"
         write(ifileid,"(a)") "    KEEP_SPACE_GROUP F #If T, then space group will be detected and preserved"
-        write(ifileid,"(a)") "    TYPE DIRECT_CELL_OPT #Geometry and cell are optimized at the same time. Can also be GEO_OPT, MD"
+        !write(ifileid,"(a)") "    TYPE DIRECT_CELL_OPT #Geometry and cell are optimized at the same time. Can also be GEO_OPT, MD". No longer available since CP2K 2026.2
         write(ifileid,"(a)") "    #The following thresholds of optimization convergence are the default ones"
         write(ifileid,"(a)") "    MAX_DR 3E-3 #Maximum geometry change"
         write(ifileid,"(a)") "    RMS_DR 1.5E-3 #RMS geometry change"

--- a/define.f90
+++ b/define.f90
@@ -615,8 +615,8 @@ end module
 !For NAOset, NAOocc, NAOene, the second index is spin, 0/1/2=total/alpha/beta. For other NAO related arrays, they are independent of spin
 module NAOmod
 integer iopshNAO !0: Closed shell, 1: Open shell (total, alpha and beta are respectively analyzed). This variable is set during loadNAOinfo
-integer ncenter_NAO !The number of centers in involved in NAO analysis, usually equals to ncenter
-character(len=2),allocatable :: atmname_NAO(:) !Name of centers in involved in NAO analysis, e.g. C, H, O, usually equals to a%name
+integer ncenter_NAO !The number of centers in involved in NAO analysis, usually equals ncenter
+character(len=2),allocatable :: atmname_NAO(:) !Name of centers in involved in NAO analysis, e.g. C, H, O, usually equals a%name
 !NAO information
 integer numNAO !The number of NAOs
 integer,allocatable :: NAOinit(:),NAOend(:) !size of ncenter_NAO. Initial and ending indices of NAOs of atoms

--- a/deloc_aromat.f90
+++ b/deloc_aromat.f90
@@ -890,7 +890,7 @@ do while(.true.)
 	write(*,*) "Input atom indices, e.g. 3,4,7,8,10   (number of centers is arbitrary)"
     write(*,"(a)") " Note: The input order must be in consistency with atomic connectivity. You can also input e.g. 4-10 if the indices are contiguous"
 	write(*,*) "Input -3/-4/-5/-6 will search all possible three/four/five/six-center bonds"
-	write(*,*) "Input 0 can return to upper level menu"
+	write(*,*) "Input 0 can return to upper-level menu"
 	read(*,"(a)") c2000tmp
 
 	if (c2000tmp(1:1)=='0') then

--- a/excittrans.f90
+++ b/excittrans.f90
@@ -5423,8 +5423,8 @@ deallocate(tmparr,tmpmat)
 ! 		!Four points:
 ! 		!1) The negative sign: Because we ignored the negative sign when evaluating magnetic integrals
 ! 		!2) Diveded by two: Necessary by definition
-! 		!3) 2.54174619D-018: convert electric dipole moment from a.u. to cgs, see gabedit build-in converter
-! 		!4) 1.85480184D-020: convert magnetic dipole moment from a.u. to cgs, see gabedit build-in converter
+! 		!3) 2.54174619D-018: convert electric dipole moment from a.u. to cgs, see gabedit built-in converter
+! 		!4) 1.85480184D-020: convert magnetic dipole moment from a.u. to cgs, see gabedit built-in converter
 ! 		Rlen=-(Teledipx*Tmagdipx+Teledipy*Tmagdipy+Teledipz*Tmagdipz)/2D0*2.54174619D-018*1.85480184D-020 *1D40
 ! 		write(*,"(' Rotatory strength in length representation:',f14.8,' 10^-40 cgs')") Rlen
 ! 		cycle

--- a/excittrans.f90
+++ b/excittrans.f90
@@ -3731,6 +3731,17 @@ call loadallexcinfo(1)
 call selexcit(istate)
 call loadexccoeff(istate,1)
 
+!SF-TDDFT is not supported, which contains a->b
+if (wfntype==1) then
+	do iexcitorb=1,excnorb
+		if (orbleft(iexcitorb)<=nbasis.and.orbright(iexcitorb)>nbasis) then
+			write(*,"(/,a)") " Error: This seems to be a spin-flip calculation, NTO is not supported for this case. Press ENTER button to return"
+			read(*,*)
+			return
+		end if
+	end do
+end if
+
 NTOvalcoeff=2
 if (allocated(CObasb)) NTOvalcoeff=1
 

--- a/fileIO.f90
+++ b/fileIO.f90
@@ -571,7 +571,7 @@ if (index(c80,"P(S=P) Contraction coefficients")/=0) then
 end if
 
 if (infomode==0) write(*,*) "Loading orbitals..."
-!Note: Some basis maybe removed by linear dependence checking, hence the number of orbitals in .fch may less than nbasis(always equals to nmo in Multiwfn)
+!Note: Some basis maybe removed by linear dependence checking, hence the number of orbitals in .fch may less than nbasis(always equals nmo in Multiwfn)
 !Hence when reading information involving the number of orbitals in .fch, use nindbasis instead nmo
 !The expansion coefficients, energies in those undefined orbitals are all set to zero
 if (wfntype==0.or.wfntype==2.or.wfntype==3) then !Restricted/restricted open-shell, saveNO/NBO
@@ -3064,7 +3064,7 @@ end if
 
 if (ionlygrid==0) then
 	do i=1,ncenter
-		read(10,*) a(i)%index,a(i)%charge,a(i)%x,a(i)%y,a(i)%z !%value is its charge, if ECP was used, it not equal to atomindex
+		read(10,*) a(i)%index,a(i)%charge,a(i)%x,a(i)%y,a(i)%z !%value is its charge, if ECP was used, it is not equal to atomindex
 	end do
 	a%name=ind2name(a%index)
 else if (ionlygrid==1) then
@@ -3217,7 +3217,7 @@ if (allocated(cubmattmp)) deallocate(cubmattmp)
 allocate(cubmattmp(nx,ny,nz)) !nx,ny,nz is identical to cubmat that already loaded into memory
 
 do i=1,ncentertmp
-	read(10,*) !Skip a(i)%index,a(i)%charge,a(i)%x,a(i)%y,a(i)%z !%value is its charge, if ECP was used, it not equal to atomindex
+	read(10,*) !Skip a(i)%index,a(i)%charge,a(i)%x,a(i)%y,a(i)%z !%value is its charge, if ECP was used, it not equals atomindex
 end do
 
 if (mo_number==1) then
@@ -5261,7 +5261,7 @@ nbasisCar=nbasis
 
 if (infomode==0) write(*,*) "Loading orbitals..."
 
-!  "nmoactual" below is the actual number of MOs (for each spin in unrestricted case), less or equal to nbasis
+!  "nmoactual" below is the actual number of MOs (for each spin in unrestricted case), which is less or equal to nbasis
 !  In GAMESS-US, the actual number of orbitals is nbasis - A - B, where
 !A is "NUMBER OF SPHERICAL CONTAMINANTS DROPPED", namely the difference betweem number of spherical and cartesian basis functions
 !B is "NUMBER OF LINEARLY DEPENDENT MOS DROPPED", namely the number of removed linearly dependent basis functions

--- a/fileIO.f90
+++ b/fileIO.f90
@@ -3099,14 +3099,35 @@ if (infomode<2) write(*,*) "Loading grid data, please wait..."
 !Note that data in cube file is recorded in reverse order as Fortran array
 if (mo_number==0.or.mo_number==1) then !Commonly case, below code has the best compatibility
 	allocate(tmpreadcub(nz,ny,nx))
-	read(10,*) tmpreadcub(:,:,:)
-	do i=1,nx
-		do j=1,ny
-			do k=1,nz
-				cubmat(i,j,k)=tmpreadcub(k,j,i)
+	read(10,*,iostat=ierror) tmpreadcub(:,:,:)
+    if (ierror==0) then
+		do i=1,nx
+			do j=1,ny
+				do k=1,nz
+					cubmat(i,j,k)=tmpreadcub(k,j,i)
+				end do
 			end do
 		end do
-	end do
+    else !CP2K 2026.1 using 6E13.5E3 to output (http://bbs.keinsci.com/thread-60030-1-1.html), making Multiwfn compatible with it
+		write(*,*) "Unable to load grid data using free format, trying loading using 6E13.5E3..."
+        rewind(10)
+        call skiplines(10,ncenter+6)
+		read(10,"(6E13.5E3)",iostat=ierror) tmpreadcub(:,:,:)
+        if (ierror/=0) then
+			write(*,*) "Unable to load grid data, the format should be problematic"
+            write(*,*) "Press ENTER buton to exit"
+            read(*,*)
+            stop
+        else
+			do i=1,nx
+				do j=1,ny
+					do k=1,nz
+						cubmat(i,j,k)=tmpreadcub(k,j,i)
+					end do
+				end do
+			end do
+        end if
+    end if
 	deallocate(tmpreadcub)
 else !Load specified of many orbitals
 	do i=1,nx
@@ -4151,11 +4172,17 @@ call loclabel(10,"[Cell]",ifound,maxline=50)
 if (ifound==0) call loclabel(10,"[cell]",ifound,maxline=50)
 if (ifound==0) call loclabel(10,"[CELL]",ifound,maxline=50)
 if (ifound==1) then
-    read(10,*)
+    read(10,"(a)") c80tmp
+    iBohrunit=0
+    if (index(c80tmp,"AU")/=0.or.index(c80tmp,"Au")/=0) iBohrunit=1
     read(10,"(a)") c80tmp
     read(c80tmp,*,iostat=ierror) alen,blen,clen,anga,angb,angc
     if (ierror==0) then !Load as cell parameters
-        call abc2cellv(alen/b2a,blen/b2a,clen/b2a,anga,angb,angc)
+		if (iBohrunit==0) then
+	        call abc2cellv(alen/b2a,blen/b2a,clen/b2a,anga,angb,angc)
+        else
+	        call abc2cellv(alen,blen,clen,anga,angb,angc)
+        end if
         ifPBC=3
     else !Load as cell vectors
 		ipos=index(c80tmp,'A')
@@ -4180,9 +4207,11 @@ if (ifound==1) then
                 ifPBC=ifPBC+1
             end if
         end if
-        cellv1=cellv1/b2a
-        cellv2=cellv2/b2a
-        cellv3=cellv3/b2a
+		if (iBohrunit==0) then
+			cellv1=cellv1/b2a
+			cellv2=cellv2/b2a
+			cellv3=cellv3/b2a
+        end if
     end if
 else
 	call loadcellinfo_txt !Load cell information from [Cell].txt in current folder if available
@@ -4308,6 +4337,7 @@ if (iorca==1) then
     call skiplines(10,ncenter+1)
     read(10,*) c80tmp
     if (index(c80tmp,"[Pseudo]")/=0) then
+		write(*,*) "Loading [Pseudo] field"
 		do while(.true.)
 			read(10,"(a)",iostat=ierror) c80
 			if (ierror/=0.or.c80==" ".or.index(c80,'[')/=0) exit
@@ -4315,6 +4345,19 @@ if (iorca==1) then
             a(idx)%charge=ichg
             if (infomode==0) write(*,"(' Note: Nuclear charge of atom',i6,' has been set to',i4)") idx,ichg
 		end do
+    end if
+else !CP2K may also contain [Pseudo]
+	call loclabel(10,"[Pseudo]",ifound,maxline=ncenter+20)
+    if (ifound==1) then
+		write(*,*) "Loading [Pseudo] field"
+        read(10,*)
+        do iatm=1,ncenter
+            read(10,*) c80tmp,idx,ichg
+            if (ichg/=a(idx)%charge) then
+				a(idx)%charge=ichg
+				if (infomode==0) write(*,"(' Note: Nuclear charge of atom',i6,' has been changed to',i4)") idx,ichg
+            end if
+        end do
     end if
 end if
 
@@ -9400,6 +9443,11 @@ do iatm=1,ncenter_tmp
             exit
         end if
     end do
+    !Sometimes the label is e.g. Zr+4 and O-2, change them to Zr and O
+    itmp=index(c80tmp,'-')
+    if (itmp/=0) c80tmp(itmp:)=" "
+    itmp=index(c80tmp,'+')
+    if (itmp/=0) c80tmp(itmp:)=" "
     a_tmp(iatm)%name=trim(c80tmp)
     !Detect element index
     call elename2idx(a_tmp(iatm)%name,a_tmp(iatm)%index)
@@ -9408,7 +9456,6 @@ do iatm=1,ncenter_tmp
     call remove_parentheses(strarr(ifrtxlab))
     call remove_parentheses(strarr(ifrtylab))
     call remove_parentheses(strarr(ifrtzlab))
-    !write(*,"(i5,1x,a,1x,a,1x,a,1x,a)") iatm,trim(strarr(iatmsitelab)),trim(strarr(ifrtxlab)),trim(strarr(ifrtylab)),trim(strarr(ifrtzlab))
     read(strarr(ifrtxlab),*) a_tmp(iatm)%x
     read(strarr(ifrtylab),*) a_tmp(iatm)%y
     read(strarr(ifrtzlab),*) a_tmp(iatm)%z

--- a/fuzzy.f90
+++ b/fuzzy.f90
@@ -2183,7 +2183,7 @@ else if (isel==10) then !PLR
 else if (isel==11) then !Multicenter DI
 	do while(.true.)
 		write(*,*) "Input atom indices, e.g. 3,4,7,8,10    (Up to 10 atoms)"
-		write(*,*) "Input q can return to upper level menu"
+		write(*,*) "Input q can return to upper-level menu"
 		read(*,"(a)") c80inp
 		if (c80inp(1:1)=='q') then
 			exit

--- a/grid.f90
+++ b/grid.f90
@@ -260,14 +260,14 @@ else
 		write(*,*) "Please select a method to set up grid"
         if (ifPBC==0) then
 			write(*,"(a,f7.3,a)") " -10 Set extension distance of grid range for mode 1~4, current:",aug3D," Bohr"
-			write(*,*) "1 Low quality grid,    covering whole system, about 125000 points in total"
-			write(*,*) "2 Medium quality grid, covering whole system, about 512000 points in total"
-			write(*,*) "3 High quality grid,   covering whole system, about 1728000 points in total"
+			write(*,*) "1 Low-quality grid,    covering whole system, about 125000 points in total"
+			write(*,*) "2 Medium-quality grid, covering whole system, about 512000 points in total"
+			write(*,*) "3 High-quality grid,   covering whole system, about 1728000 points in total"
 			write(*,*) "4 Input the number of points or grid spacing in X,Y,Z, covering whole system"
         else
-			write(*,"(a,f4.2,a,i11)") " 1 Low quality grid, covering whole cell,    spacing=",spclowqual," Bohr, grids:",ntotlow
-			write(*,"(a,f4.2,a,i11)") " 2 Medium quality grid, covering whole cell, spacing=",spcmedqual," Bohr, grids:",ntotmed
-			write(*,"(a,f4.2,a,i11)") " 3 High quality grid, covering whole cell,   spacing=",spchighqual," Bohr, grids:",ntothigh
+			write(*,"(a,f4.2,a,i11)") " 1 Low-quality grid, covering whole cell,    spacing=",spclowqual," Bohr, grids:",ntotlow
+			write(*,"(a,f4.2,a,i11)") " 2 Medium-quality grid, covering whole cell, spacing=",spcmedqual," Bohr, grids:",ntotmed
+			write(*,"(a,f4.2,a,i11)") " 3 High-quality grid, covering whole cell,   spacing=",spchighqual," Bohr, grids:",ntothigh
 			write(*,*) "4 Input the number of points or grid spacing in X,Y,Z, covering whole cell"
         end if
 		write(*,*) "5 Input original point, grid spacings, and the number of points"
@@ -592,10 +592,10 @@ do while(.true.)
 	
 	write(*,*) "Please select a method for setting up grid"
 	write(*,"(a,f10.5,a)") " -10 Set grid extension distance for mode 1~6, current:",aug3D," Bohr"
-	write(*,"(a,f4.2,a,i14)") " 1 Low quality grid, spacing=",spclowqual," Bohr, number of grids:    ",ntotlow
-	write(*,"(a,f4.2,a,i14)") " 2 Medium quality grid, spacing=",spcmedqual," Bohr, number of grids: ",ntotmed
-	write(*,"(a,f4.2,a,i14)") " 3 High quality grid, spacing=",spchighqual," Bohr, number of grids:   ",ntothigh
-	write(*,"(a,f4.2,a,i14)") " 4 Lunatic quality grid, spacing=",spclunaqual," Bohr, number of grids:",ntotluna
+	write(*,"(a,f4.2,a,i14)") " 1 Low-quality grid, spacing=",spclowqual," Bohr, number of grids:    ",ntotlow
+	write(*,"(a,f4.2,a,i14)") " 2 Medium-quality grid, spacing=",spcmedqual," Bohr, number of grids: ",ntotmed
+	write(*,"(a,f4.2,a,i14)") " 3 High-quality grid, spacing=",spchighqual," Bohr, number of grids:   ",ntothigh
+	write(*,"(a,f4.2,a,i14)") " 4 Lunatic-quality grid, spacing=",spclunaqual," Bohr, number of grids:",ntotluna
 	write(*,*) "5 Only input grid spacing, automatically set other parameters"
 	write(*,*) "6 Only input the number of points in X,Y,Z, automatically set other parameters"
 	write(*,*) "7 Input original point, grid spacings, and number of points"

--- a/orbcomp.f90
+++ b/orbcomp.f90
@@ -704,7 +704,7 @@ if (ifPBC==0) then !Using atomic-center grids to calculate intermediate array
 		write(*,*)
 		if (itype==1) then
 			write(*,*) "Hirshfeld analysis requests atomic densities, please select how to obtain them"
-			write(*,*) "1 Use build-in sphericalized atomic densities in free-states (recommended)"
+			write(*,*) "1 Use built-in sphericalized atomic densities in free-states (recommended)"
 			write(*,"(a)") " 2 Provide wavefunction file of involved elements by yourself or invoke Gaussian to automatically calculate them"
 			read(*,*) ihirshmode
 		end if
@@ -1271,7 +1271,7 @@ call checkNPA(ifound);if (ifound==0) return
 call loadNAOinfo
 
 !Get actual number of MOs
-!Gaussian may eliminate some linear dependency basis functions, so MO may be smaller than numNAO. NBsUse always equals to actual number of MO
+!Gaussian may eliminate some linear dependency basis functions, so MO may be smaller than numNAO. NBsUse always equals actual number of MO
 call loclabel(10,"NBsUse=",ifound)
 if (ifound==1) then
 	read(10,"(a)") c80tmp

--- a/orbcomp.f90
+++ b/orbcomp.f90
@@ -1061,7 +1061,7 @@ end subroutine
 !atmcomp: The array returned, atmcomp(A,i) is contribution of atom A to orbital ibeg+i-1. The second index has length of iend-ibeg+1
 !ibeg,iend: The beginning and ending index of the orbitals to be computed, ranging from 1 to nmo
 !info=0: silent mode, info=1: print intermediate prompts
-!igrid=0: Use lowest acceptable grid (accurate to one decimal place), =1: Use medium quality grid
+!igrid=0: Use lowest acceptable grid (accurate to one decimal place), =1: Use medium-quality grid
 subroutine gen_orbatmcomp_space(itype,atmcomp,ibeg,iend,info,igrid)
 use defvar
 use util

--- a/otherfunc3.f90
+++ b/otherfunc3.f90
@@ -179,9 +179,9 @@ do while(.true.)
     grdspcv2=v2len/(ny-1)
     grdspcv3=v3len/(nz-1)
     if (ifPBC==3) then
-        gridv1(:)=cellv1(:)/v1len*grdspcv1
-        gridv2(:)=cellv2(:)/v2len*grdspcv2
-        gridv3(:)=cellv3(:)/v3len*grdspcv3
+        gridv1(:)=cellv1(:)/dsqrt(sum(cellv1**2))*grdspcv1
+        gridv2(:)=cellv2(:)/dsqrt(sum(cellv2**2))*grdspcv2
+        gridv3(:)=cellv3(:)/dsqrt(sum(cellv3**2))*grdspcv3
     else
         gridv1(:)=(/ grdspcv1,0D0,0D0 /)
         gridv2(:)=(/ 0D0,grdspcv2,0D0 /)

--- a/otherfunc3.f90
+++ b/otherfunc3.f90
@@ -373,7 +373,7 @@ real*8,allocatable :: fiterr(:),fitrho(:) !Fitting error and fitted density at e
 integer :: npoint_CB=0
 real*8,allocatable :: radr_CB(:),radw_CB(:),rho_CB(:) !Position, weight and sphericalized density at second kind Gauss-Chebyshev points
 real*8 :: tol=1D-5 !Fitting tolerance. Should not be too small, otherwise it is too difficult to converge until reach maximum of function calls
-integer :: iscale=1 !=1: Scale coefficients so that integral equals to actual number of electrons, =0: Do not scale
+integer :: iscale=1 !=1: Scale coefficients so that integral equals actual number of electrons, =0: Do not scale
 integer :: isort=1,idelredun=1
 external :: atmdens_fiterr
 integer,parameter :: nsphpt=170 !Number of points used to calculate sphericalized radial density

--- a/plot.f90
+++ b/plot.f90
@@ -25,7 +25,7 @@ character ctemp*5,c80tmp*80
 !Note that due to limitation of DISLIN, it is not possible to view molecule in all viewpoints. The YVU should be limited to between -90 and 90, else the viewpoint will suddently flip
 XVUold=XVU
 YVUold=YVU
-if (YVU==90) YVU=89.999D0 !Temporarily modify YVU, otherwise when YVU equals to 90 or -90, the perspective will jump suddenly
+if (YVU==90) YVU=89.999D0 !Temporarily modify YVU, otherwise when YVU equals 90 or -90, the perspective will jump suddenly
 if (YVU==-90) YVU=-89.999D0
 
 !Determine x/y/zlow, x/y/zhigh and plotlenx/y/z, which are lower, upper positions and length of the axis

--- a/population.f90
+++ b/population.f90
@@ -5310,8 +5310,8 @@ if (iset==1) then !Parameters fitted to Mulliken charge at HF/STO-3G, Int. J. Mo
 	Bparm(7,2)= 0.611D0
 	Aparm(8,2)= 2.580D0  !O,multi=2
 	Bparm(8,2)= 0.691D0
-else if (iset==2) then !Parameters fitted to CHELPG charges at B3LYP/6-31G*, J. Comput. Chem., 30, 1174 (2009)
-	write(*,"(a)") " Parameters have been set to those fitted to CHELPG charges at B3LYP/6-31G*, see J. Comput. Chem., 30, 1174 (2009)"
+else if (iset==2) then !Parameters fitted to MK charges at B3LYP/6-31G*, J. Comput. Chem., 30, 1174 (2009)
+	write(*,"(a)") " Parameters have been set to those fitted to MK charges at B3LYP/6-31G*, see J. Comput. Chem., 30, 1174 (2009)"
 	kappa=0.302D0
 	Aparm(35,1)= 2.659D0  !Br,multi=1
 	Bparm(35,1)= 1.802D0
@@ -5337,8 +5337,8 @@ else if (iset==2) then !Parameters fitted to CHELPG charges at B3LYP/6-31G*, J. 
 	Bparm(7,2)= 0.377D0
 	Aparm(8,2)= 2.789D0  !O,multi=2
 	Bparm(8,2)= 0.834D0
-else if (iset==3) then !Parameters fitted to CHELPG charges at HF/6-31G*, J. Comput. Chem., 30, 1174 (2009)
-	write(*,"(a)") " Parameters have been set to those fitted to CHELPG charges at HF/6-31G*, see J. Comput. Chem., 30, 1174 (2009)"
+else if (iset==3) then !Parameters fitted to MK charges at HF/6-31G*, J. Comput. Chem., 30, 1174 (2009)
+	write(*,"(a)") " Parameters have been set to those fitted to MK charges at HF/6-31G*, see J. Comput. Chem., 30, 1174 (2009)"
 	kappa=0.227D0
 	Aparm(35,1)= 2.615D0  !Br,multi=1
 	Bparm(35,1)= 1.436D0

--- a/population.f90
+++ b/population.f90
@@ -259,7 +259,7 @@ end if
 end subroutine
 
 
-!!---------- Calculate Coulomb interaction between two fragment based on atomic charges in .chg file
+!!---------- Calculate Coulomb interaction between two fragments based on atomic charges in .chg file
 subroutine coulint_atmchg
 use defvar
 use util
@@ -911,13 +911,13 @@ call gen1cintgrid(gridatmorg,iradcut)
 if (chgtype==1.or.chgtype==2.or.chgtype==6.or.chgtype==7.or.chgtype==-7) then
     if (ifPBC==0) then
 	    write(*,*) "This task requests atomic densities, please select how to obtain them"
-	    write(*,*) "1 Use build-in sphericalized atomic densities in free-states (more convenient)"
+	    write(*,*) "1 Use built-in sphericalized atomic densities in free-states (more convenient)"
 	    write(*,"(a)") " 2 Provide wavefunction file of involved elements by yourself or invoke Gaussian to automatically calculate them"
 	    read(*,*) iatmdensmode
 	    if (iatmdensmode==2) call setpromol !In this routine reload first molecule at the end
     else
         iatmdensmode=1
-        write(*,"(a)") " Note: Build-in sphericalized atomic densities in free-states will be used in the calculation"
+        write(*,"(a)") " Note: Built-in sphericalized atomic densities in free-states will be used in the calculation"
     end if
 	write(*,"(' Radial grids:',i5,'    Angular grids:',i5,'   Total:',i10)") radpot,sphpot,radpot*sphpot
 	write(*,*) "Calculating, please wait..."
@@ -5519,7 +5519,7 @@ parma(53,1)=9.90D0; parmb(53,1)=7.96D0; parmc(53,1)=0.96D0 !One bond
 !Antechamber first determines Amber atom types, then convert to Gasgeiter types according to ATOMTYPE_GAS.DEF,&
 !then checks GASPARM.DAT to determine actual parameters, finally invokes "charge.c" to carry out Gasteiger calculation.&
 !The resulting Gasteiger type can be found from intermediate file ANTECHAMBER_GAS_AT.AC
-!The O1 in below information corresponds to oxygen in =O case
+!The O1 in the following information corresponds to oxygen in =O case
 !                  a       b       c      d     formal_charge
 ! GASPARM	h	  7.17	  6.24	 -0.56	 20.02	  0.00  !numbond=1
 ! GASPARM	c1	 10.39	  9.45	  0.73	 20.57	  0.00  !numbond=1 or 2

--- a/spectrum.f90
+++ b/spectrum.f90
@@ -5672,7 +5672,7 @@ write(*,"(' CIE1931 xy:        ',2f18.10)") CIE_smallx,CIE_smally
 Rcomp =  3.2404542D0*sCIE_X  -1.5371385D0*sCIE_Y  -0.4985314D0*sCIE_Z
 Gcomp = -0.9692660D0*sCIE_X + 1.8760108D0*sCIE_Y + 0.0415560D0*sCIE_Z
 Bcomp =  0.0556434D0*sCIE_X  -0.2040259D0*sCIE_Y + 1.0572252D0*sCIE_Z
-write(*,"(a)") " Note the R,G,B values show below correspond to standard RGB (sRGB) color space"
+write(*,"(a)") " Note the R,G,B values shown below correspond to standard RGB (sRGB) color space"
 write(*,"(' RGB (0-1):  ',3f10.6)") Rcomp,Gcomp,Bcomp
 intRcomp=nint(Rcomp*255);intGcomp=nint(Gcomp*255);intBcomp=nint(Bcomp*255)
 write(*,"(' RGB (0-255):',3i6)") intRcomp,intGcomp,intBcomp

--- a/spectrum.f90
+++ b/spectrum.f90
@@ -827,56 +827,71 @@ do while(.true.)
         end if
         write(*,*)
 		if (ispectrum==1.or.ispectrum==2.or.ispectrum==5.or.ispectrum==6) then !Vibrational spectra, mode selection is viable
-			write(*,*) "Input the index range of the transitions you want to scaled"
-			write(*,*) "e.g. 1,3-6,22 means selecting transitions 1,3,4,5,6,22"
-            write(*,*) "If you want to select transitions according to frequency range, input ""f"" now"
+			write(*,"(a)") " Input index range of the transitions you want to scaled, e.g. 1,3-6,22"
+            write(*,"(a)") " If you want to select according to frequency range, input ""f"" now"
 			write(*,"(a)") " Note: Press ENTER button directly can select all modes. Input 0 can return"
             if (nsystem==1) write(*,"(a,i6,a)") " Note: There are",numdata," frequencies in total"
+            write(*,"(a)") "   To apply power-law scaling factor for all frequencies, directly input lambda_1 and lambda_2, e.g. 1.217240,0.969138 (this was fitted for B3LYP/6-31G*)"
 			read(*,"(a)") c200tmp
-            if (index(c200tmp,'f')/=0) then !Select according to frequency, applied to all systems
-				write(*,*) "Input lower limit of frequency in cm^-1, e.g. 1500"
-                read(*,*) flow
-				write(*,*) "Input upper limit of frequency in cm^-1, e.g. 4000"
-                read(*,*) fup
-				write(*,*) "Input scale factor, e.g. 0.97"
-                read(*,*) tmpval
-                nscl=0
-                do isystem=1,nsystem
-					do imode=1,numdataall(isystem)
-						if (dataxall(isystem,imode)>=flow.and.dataxall(isystem,imode)<=fup) then
-							dataxall(isystem,imode)=dataxall(isystem,imode)*tmpval
-                            nscl=nscl+1
-                        end if
+            !Check if two float numbers are inputted
+            ipower=0
+            read(c200tmp,*,iostat=ierror) tmp1,tmp2
+            if (ierror==0) then
+				if ((abs(tmp1-nint(tmp1))>1D-10.or.abs(tmp2-nint(tmp2))>1D-10).and.index(c200tmp,'-')==0) ipower=1
+            end if
+            if (ipower==0) then
+				if (index(c200tmp,'f')/=0) then !Select according to frequency, applied to all systems
+					write(*,*) "Input lower limit of frequency in cm^-1, e.g. 1500"
+					read(*,*) flow
+					write(*,*) "Input upper limit of frequency in cm^-1, e.g. 4000"
+					read(*,*) fup
+					write(*,*) "Input scale factor, e.g. 0.97"
+					read(*,*) tmpval
+					nscl=0
+					do isystem=1,nsystem
+						do imode=1,numdataall(isystem)
+							if (dataxall(isystem,imode)>=flow.and.dataxall(isystem,imode)<=fup) then
+								dataxall(isystem,imode)=dataxall(isystem,imode)*tmpval
+								nscl=nscl+1
+							end if
+						end do
 					end do
-                end do
-                write(*,"(' Done!',i8,' frequencies have been scaled')") nsclall
-			else if (c200tmp(1:1)=='0') then
-                cycle
-            else !Select according to index, or select 
-				if (c200tmp==' '.or.index(c200tmp,"all")/=0) then !Selected all modes
-					nmode=numdata
-					allocate(tmparr(numdata))
-					forall(itmp=1:numdata) tmparr(itmp)=itmp
-				else
-					call str2arr(c200tmp,nmode)
-					allocate(tmparr(nmode))
-					call str2arr(c200tmp,nmode,tmparr)
+					write(*,"(' Done!',i8,' frequencies have been scaled')") nsclall
+				else if (c200tmp(1:1)=='0') then
+					cycle
+				else !Select according to index, or select 
+					if (c200tmp==' '.or.index(c200tmp,"all")/=0) then !Selected all modes
+						nmode=numdata
+						allocate(tmparr(numdata))
+						forall(itmp=1:numdata) tmparr(itmp)=itmp
+					else
+						call str2arr(c200tmp,nmode)
+						allocate(tmparr(nmode))
+						call str2arr(c200tmp,nmode,tmparr)
+					end if
+					write(*,"(i6,' frequencies are selected')") nmode
+					write(*,"(/,a)") " Input scale factor, e.g. 0.97"
+					write(*,"(a)") " Note: If pressing ENTER button directly, 0.9614 will be used, which is recommended for B3LYP/6-31G* level. &
+					&If inputting 1.0, frequencies will correspond to the ones originally loaded from input file"
+					read(*,"(a)") c200tmp
+					if (c200tmp==" ") then
+						tmpval=0.9614D0
+					else
+						read(c200tmp,*) tmpval
+					end if
+					do idx=1,nmode
+						dataxall(:,tmparr(idx))=dataxall(:,tmparr(idx))*tmpval
+					end do
+					deallocate(tmparr)
+					write(*,*) "Done! Frequencies have been scaled"
 				end if
-				write(*,"(i6,' frequencies are selected')") nmode
-				write(*,"(/,a)") " Input scale factor, e.g. 0.97"
-				write(*,"(a)") " Note: If pressing ENTER button directly, 0.9614 will be used, which is recommended for B3LYP/6-31G* level. &
-				&If inputting 1.0, frequencies will correspond to the ones originally loaded from input file"
-				read(*,"(a)") c200tmp
-				if (c200tmp==" ") then
-					tmpval=0.9614D0
-				else
-					read(c200tmp,*) tmpval
-				end if
-				do idx=1,nmode
-					dataxall(:,tmparr(idx))=dataxall(:,tmparr(idx))*tmpval
+            else
+				do isystem=1,nsystem
+					do imode=1,numdataall(isystem)
+                        dataxall(isystem,imode)=tmp1*dataxall(isystem,imode)**tmp2
+					end do
 				end do
-				deallocate(tmparr)
-                write(*,*) "Done! Frequencies have been scaled"
+				write(*,*) "Done!"
             end if
 		else !Electronic spectra, use universal scaling
 			write(*,*) "Input the scale factor, e.g. 0.92"
@@ -2176,7 +2191,7 @@ do while(.true.)
 		if (ibroadfunc==1.or.ibroadfunc==3) then !Lorentzian function or Pseudo-Voigt function, see http://mathworld.wolfram.com/LorentzianFunction.html
 			do imol=1,nsystem
 				do idata=1,numdataall(imol) !Cycle each transition
-					preterm=strall(imol,idata)*0.5D0/pi*FWHMall(imol,idata) !Integral of the peak equals to str(idata)
+					preterm=strall(imol,idata)*0.5D0/pi*FWHMall(imol,idata) !Integral of the peak equals str(idata)
 					do ipoint=1,num1Dpoints
 						curveytmp(ipoint)=preterm/( (curvex(ipoint)-dataxall(imol,idata))**2+0.25D0*FWHMall(imol,idata)**2 )
 					end do
@@ -5124,7 +5139,7 @@ do while(.true.)
 		curveyall=0D0
 		do imol=1,nsystem
 			do iterm=1,shdnum(imol)
-				preterm=shdeffnatm(iterm,imol)*0.5D0/pi*FWHM_NMR !Integral of the peak equals to degeneracy
+				preterm=shdeffnatm(iterm,imol)*0.5D0/pi*FWHM_NMR !Integral of the peak equals degeneracy
 				do ipoint=1,num1Dpoints
 					curveytmp(ipoint)=preterm/( (curvex(ipoint)-shdval(iterm,imol))**2+0.25D0*FWHM_NMR**2 )
 				end do
@@ -5134,7 +5149,7 @@ do while(.true.)
         curveywei=0D0
         if (ishowweighted/=0) then
             do iterm=1,shdnumwei
-				preterm=shdeffnatmwei(iterm)*0.5D0/pi*FWHM_NMR !Integral of the peak equals to degeneracy
+				preterm=shdeffnatmwei(iterm)*0.5D0/pi*FWHM_NMR !Integral of the peak equals degeneracy
 				do ipoint=1,num1Dpoints
 					curveytmp(ipoint)=preterm/( (curvex(ipoint)-shdvalwei(iterm))**2+0.25D0*FWHM_NMR**2 )
 				end do

--- a/sub.f90
+++ b/sub.f90
@@ -2375,7 +2375,7 @@ if (allocated(b)) then !If loaded file contains wavefuntion information
 	write(ifileid,"(' Hamiltonian kinetic energy K(r):',E18.10)") valK
 ! 	valKx=Hamkin(inx,iny,inz,1);valKy=Hamkin(inx,iny,inz,2);valKz=Hamkin(inx,iny,inz,3)
 ! 	write(ifileid,"(' K(r) in X,Y,Z:',3E18.10)") valKx,valKy,valKz
-	write(ifileid,"(' Potential energy density V(r):',E18.10)") -valK-valG !When without EDF, also equals to flapl(inx,iny,inz,'t')/4D0-2*valG
+	write(ifileid,"(' Potential energy density V(r):',E18.10)") -valK-valG !When without EDF, also equals flapl(inx,iny,inz,'t')/4D0-2*valG
 	write(ifileid,"(' Energy density E(r) or H(r):',E18.10)") -valK
 	write(ifileid,"(' Laplacian of electron density:',E18.10)") laplfac*(elehess(1,1)+elehess(2,2)+elehess(3,3))
 	write(ifileid,"(' Electron localization function (ELF):',E18.10)") ELF_LOL(inx,iny,inz,"ELF")
@@ -2444,24 +2444,24 @@ end if
 
 write(ifileid,*)
 if (ifuncsel==1) then
-	write(ifileid,*) "Note: Below information is for electron density"
+	write(ifileid,*) "Note: The following information is for electron density"
 	funchess=elehess
 	funcgrad=elegrad
 else
 	if (ifuncsel==3) then
-        write(ifileid,*) "Note: Below information is for Laplacian of electron density"
+        write(ifileid,*) "Note: The following information is for Laplacian of electron density"
 	else if (ifuncsel==4) then
-        write(ifileid,*) "Note: Below information is for value of orbital wavefunction"
+        write(ifileid,*) "Note: The following information is for value of orbital wavefunction"
 	else if (ifuncsel==9) then
-        write(ifileid,*) "Note: Below information is for electron localization function"
+        write(ifileid,*) "Note: The following information is for electron localization function"
 	else if (ifuncsel==10) then
-        write(ifileid,*) "Note: Below information is for localized orbital locator"
+        write(ifileid,*) "Note: The following information is for localized orbital locator"
 	else if (ifuncsel==12) then
-        write(ifileid,*) "Note: Below information is for total ESP"
+        write(ifileid,*) "Note: The following information is for total ESP"
 	else if (ifuncsel==100) then
-        write(ifileid,*) "Note: Below information is for user-defined real space function"
+        write(ifileid,*) "Note: The following information is for user-defined real space function"
 	else
-        write(ifileid,"(a,i4)") " Note: Below information is for real space function",ifuncsel
+        write(ifileid,"(a,i4)") " Note: The following information is for real space function",ifuncsel
     end if
 	call gencalchessmat(2,ifuncsel,inx,iny,inz,funcvalue,funcgrad,funchess)
 end if
@@ -3275,9 +3275,9 @@ end subroutine
 
 !!------- Calculate Tian Lu weighting function of iatm at (x,y,z). PBC is taken into account
 !Calculate value of simple atomic decaying function for all atoms, and finally calculate weight of iatm using Hirshfeld-like manner
-!itype=1: Error function type. xscale = 0.85, leading to modest sharpness. Weight of 0.5 equals to CSD covalent radii
+!itype=1: Error function type. xscale = 0.85, leading to modest sharpness. Weight of 0.5 equals CSD covalent radii
 !itype=2: Gaussian function type. FWHM is CSD covalent radii
-!itype=3: Becke function type. Weight of 0.5 equals to CSD covalent radii. This is poor, because this function decays quickly to zero, making weighting function at distant region cannot be calculated
+!itype=3: Becke function type. Weight of 0.5 equals CSD covalent radii. This is poor, because this function decays quickly to zero, making weighting function at distant region cannot be calculated
 !See http://sobereva.com/539 for illustration of different weighting functions
 !
 !All the functions have deficiency, namely they become exactly zero at distant region, &

--- a/surfana.f90
+++ b/surfana.f90
@@ -292,7 +292,7 @@ do while(.true.)
 	else if (isel==4) then
 		do while(.true.)
 			write(*,*)
-			write(*,*) "0 Return to upper level menu"
+			write(*,*) "0 Return to upper-level menu"
 			write(*,"(a,f7.4)") " 1 Set ratio of vdW radii used to extend spatial region for grids:",vdwmulti
 			if (ifelim==0) write(*,*) "2 Toggle if eliminating redundant vertices: No"
 			if (ifelim==1) write(*,"(a,f6.3,a)") " 2 Toggle if eliminating redundant vertices: Yes, criterion is",critmerge," Bohr"
@@ -431,7 +431,7 @@ if (isurftype==1.or.isurftype==2.or.isurftype==5.or.isurftype==6) then !Calculat
 		cubmattmp=0D0
 		!I found ihirshmode=1 is always a satisfactory choice, so I decide not bother users to select
 		!write(*,*) "Hirshfeld analysis requests atomic densities, please select how to obtain them"
-		!write(*,*) "1 Use build-in sphericalized atomic densities in free-states (recommended)"
+		!write(*,*) "1 Use built-in sphericalized atomic densities in free-states (recommended)"
 		!write(*,"(a)") " 2 Provide wavefunction file of involved elements by yourself or invoke Gaussian to automatically calculate them"
 		!read(*,*) ihirshmode
 		!if (ihirshmode==1) then
@@ -1355,7 +1355,7 @@ do while(.true.)
 	write(*,*) "                   ---------- Post-processing menu ----------"
 	write(*,*) "-3 Visualize the surface"
 	write(*,*) "-2 Export the grid data to surf.cub in current folder"
-	write(*,*) "-1 Return to upper level menu"
+	write(*,*) "-1 Return to upper-level menu"
 	write(*,*) "0 View molecular structure, surface minima and maxima"
 	write(*,*) "1 Export surface extrema as surfanalysis.txt in current folder"
 	write(*,*) "2 Export surface extrema as surfanalysis.pdb in current folder"

--- a/util.f90
+++ b/util.f90
@@ -1917,7 +1917,7 @@ end do
 end subroutine
 
 
-!----- Convert a square matrix to an array. imode=1/2/3: Full matrix; Lower half matrix; Upper half matrix
+!----- Convert a square matrix to an array. imode=1/2/3: Full matrix; Lower half matrix; Upper half triangular matrix
 !For mode=1,2, "arr" should be nsize*(nsize+1)/2
 subroutine mat2arr(mat,arr,imode)
 implicit real*8 (a-h,o-z)

--- a/visweak.f90
+++ b/visweak.f90
@@ -1184,7 +1184,7 @@ real*8 gradtmp(3),grad_inter(3),IGM_gradnorm_inter,vec1(3),vec2(3)
 integer iIGMtype
 integer,allocatable :: IGMfrag(:,:),IGMfragsize(:) !Definition of each fragment used in IGM, and the number of atoms in each fragment
 real*8,allocatable :: frag_grad(:,:,:,:,:) !frag_grad(1:3,nx,ny,nz,nfrag), gradient vector of each fragment at every point
-real*8,allocatable :: dg_inter(:,:,:),TFI_IGM(:,:,:)
+real*8,allocatable :: dg_inter(:,:,:),TFI_IGM(:,:,:),stddg_inter(:,:,:)
 logical,allocatable :: dogrid(:,:,:),dogridtmp(:,:,:)
 !The first index of avggrad and the first two indices of avghess correspond to components of gradient and Hessian, respectively
 real*8,allocatable :: avgdens(:,:,:),avggrad(:,:,:,:),avghess(:,:,:,:,:)
@@ -1457,7 +1457,8 @@ do while (.true.)
 	!if (iIGMtype==1) write(*,*) "6 Compute TFI(aIGM) and export to TFI_aIGM.cub in current folder"
 	!if (iIGMtype==-1) write(*,*) "6 Compute TFI(amIGM) and export to TFI_amIGM.cub in current folder"
 	!write(*,"(a)") " 7 Evaluate contribution of atomic pairs and atoms to interfragment interaction (atom and atomic pair delta-g indices as well as IBSIW index)"
-	read(*,*) isel
+	write(*,"(a)") " 8 Compute standard deviation of delta-g_inter and export to stddg_inter.cub in current folder"
+    read(*,*) isel
     
 	if (isel==-3) then
 		write(*,*) "Input lower limit and upper limit of Y axis  e.g. 0,1.5"
@@ -1577,6 +1578,53 @@ do while (.true.)
 		close(10)
         write(*,*) "Done!"
 		deallocate(TFI_IGM)
+        
+    else if (isel==8) then
+		call walltime(iwalltime1)
+		write(*,*) "Calculating standard deviation of delta-g_inter..."
+		allocate(stddg_inter(nx,ny,nz))
+        stddg_inter=0
+		open(10,file=filename,status="old")
+		do ifps=1,ifpsend
+			call readxyztrj(10)
+			if (ifps<ifpsstart) cycle
+			call showprog(ifps,nfps)
+			!$OMP PARALLEL DO SHARED(stddg_inter) PRIVATE(i,j,k,ifrag,gradtmp,grad_inter,IGM_gradnorm_inter,tmpx,tmpy,tmpz) schedule(dynamic) NUM_THREADS(nthreads)
+			do k=1,nz
+				do j=1,ny
+					do i=1,nx
+						call getgridxyz(i,j,k,tmpx,tmpy,tmpz)
+						grad_inter=0
+						IGM_gradnorm_inter=0
+						do ifrag=1,nIGMfrag
+							call IGMgrad_Hirshpromol(tmpx,tmpy,tmpz,IGMfrag(ifrag,1:IGMfragsize(ifrag)),gradtmp(:),rnouse) !Supports PBC
+							grad_inter(:)=grad_inter(:)+gradtmp(:)
+							IGM_gradnorm_inter=IGM_gradnorm_inter+dsqrt(sum(gradtmp**2))
+						end do
+						stddg_inter(i,j,k)=stddg_inter(i,j,k) + ( IGM_gradnorm_inter-dsqrt(sum(grad_inter**2)) - dg_inter(i,j,k) )**2
+					end do
+				end do
+			end do
+			!$OMP END PARALLEL DO
+		end do
+		close(10)
+        
+        do k=1,nz
+			do j=1,ny
+				do i=1,nx
+					stddg_inter(i,j,k)=dsqrt(stddg_inter(i,j,k)/nfps)
+				end do
+			end do
+		end do
+		write(*,*) "Exporting standard deviation of delta-g_inter to stddg_inter.cub..."
+		open(10,file="stddg_inter.cub",status="replace")
+		call outcube(stddg_inter,nx,ny,nz,orgx,orgy,orgz,gridv1,gridv2,gridv3,10)
+		close(10)
+        write(*,*) "Done!"
+		deallocate(stddg_inter)
+		call walltime(iwalltime2)
+		write(*,"(' Calculation totally took up wall clock time',i10,' s')") iwalltime2-iwalltime1
+        
     end if
 end do
 

--- a/visweak.f90
+++ b/visweak.f90
@@ -1453,11 +1453,11 @@ do while (.true.)
 	write(*,"(a)") " 3 Output averaged delta-g_inter and sign(lambda2)*rho to avgdg_inter.cub and avgsl2r.cub in current folder, respectively"
 	write(*,"(a)") " 4 Output averaged RDG to avgRDG.cub in current folder"
 	write(*,"(a)") " 5 Compute thermal fluctuation index (TFI) and export to thermflu.cub in current folder"
-    !I found the effect of mapping TFI onto dg_inter isosurface is poor (two sides of isosurface show very different color), so hidden these options
-	!if (iIGMtype==1) write(*,*) "6 Compute TFI(aIGM) and export to TFI_aIGM.cub in current folder"
+    !Option 6 of amIGM case has been merged into option 8
+ !   if (iIGMtype==1) write(*,*) "6 Compute TFI(aIGM) and export to TFI_aIGM.cub in current folder"
 	!if (iIGMtype==-1) write(*,*) "6 Compute TFI(amIGM) and export to TFI_amIGM.cub in current folder"
 	!write(*,"(a)") " 7 Evaluate contribution of atomic pairs and atoms to interfragment interaction (atom and atomic pair delta-g indices as well as IBSIW index)"
-	write(*,"(a)") " 8 Compute standard deviation of delta-g_inter and export to stddg_inter.cub in current folder"
+	write(*,"(a)") " 8 Compute and export grid data of standard deviation of delta-g_inter and TFI(amIGM)"
     read(*,*) isel
     
 	if (isel==-3) then
@@ -1521,7 +1521,8 @@ do while (.true.)
     else if (isel==5) then
         call calcexport_TFI(avgdens,ifpsstart,ifpsend)
         
-    else if (isel==6) then
+    else if (isel==6) then !This is fully meaningless
+		call walltime(iwalltime1)
 		if (iIGMtype==1) write(*,*) "Calculating grid data of TFI(aIGM)..."
 		if (iIGMtype==-1) write(*,*) "Calculating grid data of TFI(amIGM)..."
 		allocate(TFI_IGM(nx,ny,nz))
@@ -1536,6 +1537,9 @@ do while (.true.)
 			do k=1,nz
 				do j=1,ny
 					do i=1,nx
+						if (amIGMvdwscl/=0) then
+							if (dogrid(i,j,k).eqv..false.) cycle
+						end if
 						call getgridxyz(i,j,k,tmpx,tmpy,tmpz)
 						grad_inter=0
 						IGM_gradnorm_inter=0
@@ -1578,6 +1582,8 @@ do while (.true.)
 		close(10)
         write(*,*) "Done!"
 		deallocate(TFI_IGM)
+		call walltime(iwalltime2)
+		write(*,"(' Calculation totally took up wall clock time',i10,' s')") iwalltime2-iwalltime1
         
     else if (isel==8) then
 		call walltime(iwalltime1)
@@ -1593,6 +1599,9 @@ do while (.true.)
 			do k=1,nz
 				do j=1,ny
 					do i=1,nx
+						if (amIGMvdwscl/=0) then
+							if (dogrid(i,j,k).eqv..false.) cycle
+						end if
 						call getgridxyz(i,j,k,tmpx,tmpy,tmpz)
 						grad_inter=0
 						IGM_gradnorm_inter=0
@@ -1616,14 +1625,20 @@ do while (.true.)
 				end do
 			end do
 		end do
+		call walltime(iwalltime2)
+		write(*,"(' Calculation totally took up wall clock time',i10,' s')") iwalltime2-iwalltime1
+        write(*,*)
 		write(*,*) "Exporting standard deviation of delta-g_inter to stddg_inter.cub..."
 		open(10,file="stddg_inter.cub",status="replace")
 		call outcube(stddg_inter,nx,ny,nz,orgx,orgy,orgz,gridv1,gridv2,gridv3,10)
 		close(10)
+        stddg_inter(:,:,:)=stddg_inter(:,:,:)/dg_inter(:,:,:)
+		write(*,*) "Exporting TFI(amIGM) to TFI_amIGM.cub..."
+		open(10,file="TFI_amIGM.cub",status="replace")
+		call outcube(stddg_inter,nx,ny,nz,orgx,orgy,orgz,gridv1,gridv2,gridv3,10)
+		close(10)
         write(*,*) "Done!"
 		deallocate(stddg_inter)
-		call walltime(iwalltime2)
-		write(*,"(' Calculation totally took up wall clock time',i10,' s')") iwalltime2-iwalltime1
         
     end if
 end do


### PR DESCRIPTION
Sync the official Multiwfn source from 2026.7.10 to 2026.9.13 (`upstream-tracking` at `964768e9dc3cc926f62e914df140f670d966b617`), retaining the MatterViz frontend, native host and existing adapter changes. This includes CP2K fixed-width Cube input and Molden pseudo/cell metadata, charged CIF labels, periodic free-volume grid spacing, ORCA parsing guards, updated CP2K input generation, and the new grid-only loading command.

The official source merges without conflicts. Review follow-ups correct the fixed-width Cube fallback when the retained molecular atom count differs from the Cube header, use the matching aIGM/amIGM gradient in the new fluctuation export, and write zero for zero-density TFI points instead of NaN. Small follow-ups also synchronize EEM menu labels, document DOS text columns, and print the actual frequency-scaling count. Add executable regressions for CP2K's adjacent 13-column Cube fields, loading a grid without replacing the current molecular geometry, and both Molden `[Cell] AU` encodings with `[Pseudo]` valence charges. Also test fixed-width grid-only loading with different atom counts, and compare the new TFI export point-by-point with the established calculation for both aIGM and amIGM, including screened zero-density points. These run in the packaged Linux noGUI test suite.

Validation:
- Existing geometry/Cube round trips and the initial four new cases pass against the 2026.9.13 tracking CI Linux package. The additional combined Cube case reproduces the upstream failure; the TFI fixture reproduces 26 NaN values out of 27 and the wrong aIGM gradient before the fixes. All nine scenarios now pass against the integrated Linux package in a clean glibc 2.28 container ([run 35494325307](https://github.com/Stardust0831/Multiwfn/actions/runs/35494325307)).
- All required checks on final core commit `25df8b8` pass; all five inline review discussions are resolved.
- Final desktop integration is validated together with #61 in [MatterViz CI 35494339853](https://github.com/Stardust0831/Multiwfn/actions/runs/35494339853): frontend/Rust integration and actual Linux, macOS and Windows packages all pass. Its tested commit `1327303` includes `25df8b8` with identical core source and functional tests.

Source provenance remains recorded in `.multiwfn-upstream-manifest.json`. This does not claim to fix the separate ORCA ECP/genP issue #50.
